### PR TITLE
Add Policy Import Parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20200609232535-dd99544a3119
-	github.com/open-policy-agent/opa v0.19.1
+	github.com/open-policy-agent/opa v0.21.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
 	k8s.io/apimachinery v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/open-policy-agent/frameworks/constraint v0.0.0-20200609232535-dd99544
 github.com/open-policy-agent/frameworks/constraint v0.0.0-20200609232535-dd99544a3119/go.mod h1:Dr3QxvH+NTQcPPZWSt1ueNOsxW4VwgUltaLL7Ttnrac=
 github.com/open-policy-agent/opa v0.19.1 h1:jVopQC3LRwQTstVME8LDCNf6PZkShmmozDsvyp+DYZY=
 github.com/open-policy-agent/opa v0.19.1/go.mod h1:rrwxoT/b011T0cyj+gg2VvxqTtn6N3gp/jzmr3fjW44=
+github.com/open-policy-agent/opa v0.21.0 h1:0CVq4EEUP+fJEzjwd9yNLSTWZk4W5rM+QbjdLcT1nY0=
+github.com/open-policy-agent/opa v0.21.0/go.mod h1:cZaTfhxsj7QdIiUI0U9aBtOLLTqVNe+XE60+9kZKLHw=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -227,34 +227,15 @@ func getRegoFilePaths(path string) ([]string, error) {
 }
 
 func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, error) {
-	var policies, libraries []*regoPolicy
-
-	// Load the policies and libraries into memory
-	for _, file := range policyPaths {
-		data, err := ioutil.ReadFile(file)
-		if err != nil {
-			return nil, err
-		}
-		policy, err := ast.ParseModule("", string(data))
-		if err != nil {
-			return nil, err
-		}
-		policies = append(policies, &regoPolicy{path: file, policy: policy})
+	policies, err := loadPolicies(policyPaths)
+	if err != nil {
+		return nil, err
+	}
+	libraries, err := loadPolicies(libraryPaths)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, file := range libraryPaths {
-		data, err := ioutil.ReadFile(file)
-		if err != nil {
-			return nil, err
-		}
-		library, err := ast.ParseModule("", string(data))
-		if err != nil {
-			return nil, err
-		}
-		libraries = append(libraries, &regoPolicy{path: file, policy: library})
-	}
-
-	// Match each policy's imports to those available
 	for _, p := range policies {
 		if len(p.policy.Imports) > 0 {
 			for _, i := range p.policy.Imports {
@@ -273,6 +254,22 @@ func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, 
 		}
 	}
 
+	return policies, nil
+}
+
+func loadPolicies(paths []string) ([]*regoPolicy, error) {
+	var policies []*regoPolicy
+	for _, file := range paths {
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		policy, err := ast.ParseModule("", string(data))
+		if err != nil {
+			return nil, err
+		}
+		policies = append(policies, &regoPolicy{path: file, policy: policy})
+	}
 	return policies, nil
 }
 

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -234,14 +234,15 @@ func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, 
 	}
 
 	for _, p := range policies {
-		if len(p.policy.Imports) > 0 {
-			for _, i := range p.policy.Imports {
-				library := getLibrary(libraries, i.Path.String())
-				if library == nil {
-					return nil, fmt.Errorf("imported library %s not found", i.Path.String())
-				}
-				p.libraries = append(p.libraries, library.rego)
+		if len(p.policy.Imports) == 0 {
+			continue
+		}
+		for _, i := range p.policy.Imports {
+			library := getLibrary(libraries, i.Path.String())
+			if library == nil {
+				return nil, fmt.Errorf("imported library %s not found", i.Path.String())
 			}
+			p.libraries = append(p.libraries, library.rego)
 		}
 	}
 

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -24,11 +24,6 @@ type regoPolicy struct {
 	libraries []string
 }
 
-type regoLibrary struct {
-	path   string
-	policy *ast.Module
-}
-
 // NewCreateCommand creates a new create command
 func NewCreateCommand() *cobra.Command {
 	cmd := cobra.Command{
@@ -232,8 +227,7 @@ func getRegoFilePaths(path string) ([]string, error) {
 }
 
 func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, error) {
-	var policies []*regoPolicy
-	var libraries []*regoLibrary
+	var policies, libraries []*regoPolicy
 
 	// Load the policies and libraries into memory
 	for _, file := range policyPaths {
@@ -257,7 +251,7 @@ func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, 
 		if err != nil {
 			return nil, err
 		}
-		libraries = append(libraries, &regoLibrary{path: file, policy: library})
+		libraries = append(libraries, &regoPolicy{path: file, policy: library})
 	}
 
 	// Match each policy's imports to those available
@@ -282,7 +276,7 @@ func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, 
 	return policies, nil
 }
 
-func getLibrary(libraries []*regoLibrary, path string) *regoLibrary {
+func getLibrary(libraries []*regoPolicy, path string) *regoPolicy {
 	for _, library := range libraries {
 		if library.policy.Package.Path.String() == path {
 			return library

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -22,7 +22,7 @@ import (
 type regoPolicy struct {
 	path      string
 	rego      string
-	policy    *ast.Module
+	module    *ast.Module
 	libraries []string
 }
 
@@ -234,10 +234,10 @@ func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, 
 	}
 
 	for _, p := range policies {
-		if len(p.policy.Imports) == 0 {
+		if len(p.module.Imports) == 0 {
 			continue
 		}
-		for _, i := range p.policy.Imports {
+		for _, i := range p.module.Imports {
 			library := getLibrary(libraries, i.Path.String())
 			if library == nil {
 				return nil, fmt.Errorf("imported library %s not found", i.Path.String())
@@ -256,18 +256,18 @@ func loadPolicies(paths []string) ([]*regoPolicy, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "reading policy file")
 		}
-		policy, err := ast.ParseModule("", string(data))
+		module, err := ast.ParseModule("", string(data))
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing policy file")
 		}
-		policies = append(policies, &regoPolicy{path: file, rego: string(data), policy: policy})
+		policies = append(policies, &regoPolicy{path: file, rego: string(data), module: module})
 	}
 	return policies, nil
 }
 
 func getLibrary(libraries []*regoPolicy, path string) *regoPolicy {
 	for _, library := range libraries {
-		if library.policy.Package.Path.String() == path {
+		if library.module.Package.Path.String() == path {
 			return library
 		}
 	}

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -272,7 +272,7 @@ func parsePolicies(policyPaths []string, libraryPaths []string) ([]*regoPolicy, 
 				// We read the file again from disk to perserve the formatting of the policy
 				// The OPA parser removes a lot of the nice syntax sugar that makes it easier for us to read
 				// ---
-				// We just read the librarya few milliseconds ago, assuming errors won't happen on the second read
+				// We just read the library a few milliseconds ago, assuming errors won't happen on the second read
 				data, _ := ioutil.ReadFile(library.path)
 				p.libraries = append(p.libraries, string(data))
 			}


### PR DESCRIPTION
By parsing the imports, we can include only the libraries needed for each policy to work. This allows us to break out the large k8s library into multiple smaller libraries and only include those as needed. This helps make Gatekeeper more responsive as it has less Rego to parse and should result in lower memory usage by Gatekeeper as well.

In this implementation, only the imports of the policies are parsed. This means that if a library imports another library that the policy does not, it will not work. 