### PR TITLE
Allow specifying namespaces and excludedNamespaces in Constraint match criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ _Example: konstraint create --ignore combined-policies/_
 
 _Example: konstraint create --lib library_
 
+`--exclude-namespace` or `-e` excludes a namespace from the constraint. This flag can be specified more than once. Cannot be used with `--include-namespace`.
+
+_Example: konstraint create -e kube-system -e gatekeeper-system_
+
+`--include-namespace` or `-i` specifies a namespace to apply the constraint to, excluding all others. This flag can be specified more than once. Cannot be used with `--exclude-namespace`. 
+
+_Example: konstraint create -i unique-namespace_
+
 ### Doc command
 
 Generate documentation from policies that set `@Kinds` in their comment headers

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20200609232535-dd99544a3119
 	github.com/open-policy-agent/opa v0.21.0
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
 	k8s.io/apimachinery v0.18.4


### PR DESCRIPTION
This adds flags for specifying the `namespaces` and `excludedNamespaces` in the Constraint `match` criteria. 