### PR TITLE
Add output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ _Example: konstraint create --ignore combined-policies/_
 
 _Example: konstraint create --lib library_
 
+`--output` / `-o` Specify an output folder for the resources.
+
+_Example: konstraint create -o gatekeeper-resources_
+
 ### Doc command
 
 Generate documentation from policies that set `@Kinds` in their comment headers

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -101,26 +101,29 @@ func runCreateCommand(path string) error {
 		return fmt.Errorf("load libraries: %w", err)
 	}
 
+	var templateFileName, constraintFileName, outputDir string
 	outputFlag := viper.GetString("output")
+	if outputFlag == "" {
+		templateFileName = "template.yaml"
+		constraintFileName = "constraint.yaml"
+	} else {
+		outputDir = outputFlag
+	}
 
 	for _, policy := range policies {
 		policyDir := filepath.Dir(policy.filePath)
 
-		var templateFileName, constraintFileName, outputDir string
 		if outputFlag == "" {
-			templateFileName = "template.yaml"
-			constraintFileName = "constraint.yaml"
 			outputDir = policyDir
 		} else {
-			templateFileName = fmt.Sprintf("%s_template.yaml", filepath.Base(policyDir))
-			constraintFileName = fmt.Sprintf("%s_constraint.yaml", filepath.Base(policyDir))
-			outputDir = outputFlag
+			templateFileName = fmt.Sprintf("template_%s.yaml", getKindFromPath(policy.filePath))
+			constraintFileName = fmt.Sprintf("constraint_%s.yaml", getKindFromPath(policy.filePath))
 		}
 
 		if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-			err := os.Mkdir(outputDir, os.ModePerm)
+			err := os.MkdirAll(outputDir, os.ModePerm)
 			if err != nil {
-				return fmt.Errorf("unable to create output directory: %w", err)
+				return fmt.Errorf("create output directory: %w", err)
 			}
 		}
 


### PR DESCRIPTION
This adds the `--output` / `-o` flag to the `create` command to allow the generated resources to be written to a single user specified directory. This can make the flow in a delivery pipeline easier depending on the restrictions of the tooling available in that pipeline.