### PR TITLE
Add dryrun flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ _Example: konstraint create --lib library_
 
 _Example: konstraint create -o gatekeeper-resources_
 
+`--dryrun` / `-d` Sets the enforcement action of the constraints to dryrun.
+
+_Example: konstraint create -o gatekeeper-resources --dryrun_
+
 ### Doc command
 
 Generate documentation from policies that set `@Kinds` in their comment headers

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -112,8 +112,6 @@ func runCreateCommand(path string) error {
 		outputDir = outputFlag
 	}
 
-	dryrun := viper.GetBool("dryrun")
-
 	for _, policy := range policies {
 		policyDir := filepath.Dir(policy.filePath)
 
@@ -142,7 +140,7 @@ func runCreateCommand(path string) error {
 			return fmt.Errorf("writing template: %w", err)
 		}
 
-		constraint, err := getConstraint(policy, dryrun)
+		constraint, err := getConstraint(policy)
 		if err != nil {
 			return fmt.Errorf("get constraint: %w", err)
 		}
@@ -202,7 +200,7 @@ func getConstraintTemplate(policy regoFile, libraries []regoFile) v1beta1.Constr
 	return constraintTemplate
 }
 
-func getConstraint(policy regoFile, dryrun bool) (unstructured.Unstructured, error) {
+func getConstraint(policy regoFile) (unstructured.Unstructured, error) {
 	kind := getKindFromPath(policy.filePath)
 	constraint := unstructured.Unstructured{}
 	constraint.SetName(strings.ToLower(kind))
@@ -242,6 +240,7 @@ func getConstraint(policy regoFile, dryrun bool) (unstructured.Unstructured, err
 		return unstructured.Unstructured{}, fmt.Errorf("set constraint matchers: %w", err)
 	}
 
+	dryrun := viper.GetBool("dryrun")
 	if dryrun {
 		if err := unstructured.SetNestedField(constraint.Object, "dryrun", "spec", "enforcementAction"); err != nil {
 			return unstructured.Unstructured{}, fmt.Errorf("set constraint dryrun: %w", err)

--- a/internal/commands/create_test.go
+++ b/internal/commands/create_test.go
@@ -16,7 +16,7 @@ func TestGetConstraint_NoKinds_ReturnsEmptyMatcher(t *testing.T) {
 		t.Fatal("new rego file:", err)
 	}
 
-	actual, err := getConstraint(rego, false)
+	actual, err := getConstraint(rego)
 	if err != nil {
 		t.Fatal("get constraint:", err)
 	}
@@ -36,7 +36,7 @@ func TestGetConstraint_KindsInComment_ReturnsKinds(t *testing.T) {
 		t.Fatal("new rego file:", err)
 	}
 
-	actual, err := getConstraint(rego, false)
+	actual, err := getConstraint(rego)
 	if err != nil {
 		t.Fatal("get constraint:", err)
 	}

--- a/internal/commands/create_test.go
+++ b/internal/commands/create_test.go
@@ -16,7 +16,7 @@ func TestGetConstraint_NoKinds_ReturnsEmptyMatcher(t *testing.T) {
 		t.Fatal("new rego file:", err)
 	}
 
-	actual, err := getConstraint(rego)
+	actual, err := getConstraint(rego, false)
 	if err != nil {
 		t.Fatal("get constraint:", err)
 	}
@@ -36,7 +36,7 @@ func TestGetConstraint_KindsInComment_ReturnsKinds(t *testing.T) {
 		t.Fatal("new rego file:", err)
 	}
 
-	actual, err := getConstraint(rego)
+	actual, err := getConstraint(rego, false)
 	if err != nil {
 		t.Fatal("get constraint:", err)
 	}


### PR DESCRIPTION
Adds a flag to generate the constraints with `enforcementAction: dryrun`. Useful when you are deploying Gatekeeper to an existing cluster and want to audit the cluster for policy violations so they can be remediated before enforcing the policies.