### PR TITLE
container-images example: Deny if no tag is set

### DIFF
--- a/examples/container-images/src.rego
+++ b/examples/container-images/src.rego
@@ -13,3 +13,7 @@ violation[msg] {
 has_latest_tag {
   endswith(k8s.container_images[_], ":latest")
 }
+
+has_latest_tag {
+  contains(k8s.container_images[_], ":") == false
+}

--- a/examples/container-images/src_test.rego
+++ b/examples/container-images/src_test.rego
@@ -21,3 +21,14 @@ test_input_as_image_with_latest_tag {
 
   has_latest_tag with input as input
 }
+
+test_input_as_image_with_no_tag {
+  input := {
+    "kind": "Pod",
+    "spec": {
+      "containers": [{"image": "image"}]
+    }
+  }
+
+  has_latest_tag with input as input
+}

--- a/examples/container-images/template.yaml
+++ b/examples/container-images/template.yaml
@@ -308,5 +308,9 @@ spec:
       has_latest_tag {
         endswith(k8s.container_images[_], ":latest")
       }
+
+      has_latest_tag {
+        contains(k8s.container_images[_], ":") == false
+      }
     target: admission.k8s.gatekeeper.sh
 status: {}


### PR DESCRIPTION
If a tag is not specified, the `:latest` tag is automatically applied. This adds a check to ensure the image has a tag, further ensuring the `:latest` tag is not used. 