### PR TITLE
Fix output location for documentation generation

### DIFF
--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -32,6 +32,14 @@ func newCreateCommand() *cobra.Command {
 				return fmt.Errorf("bind lib flag: %w", err)
 			}
 
+			if err := viper.BindPFlag("dryrun", cmd.PersistentFlags().Lookup("dryrun")); err != nil {
+				return fmt.Errorf("bind dryrun flag: %w", err)
+			}
+
+			if err := viper.BindPFlag("output", cmd.PersistentFlags().Lookup("output")); err != nil {
+				return fmt.Errorf("bind ouput flag: %w", err)
+			}
+
 			path := "."
 			if len(args) > 0 {
 				path = args[0]
@@ -42,9 +50,7 @@ func newCreateCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringP("output", "o", "", "Specify an output directory for the Gatekeeper resources")
-	viper.BindPFlag("output", cmd.PersistentFlags().Lookup("output"))
 	cmd.PersistentFlags().BoolP("dryrun", "d", false, "Sets the enforcement action of the constraints to dryrun")
-	viper.BindPFlag("dryrun", cmd.PersistentFlags().Lookup("dryrun"))
 
 	return &cmd
 }

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -38,7 +38,7 @@ func newDocCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("output", "o", "policies.md", "output location (including filename) for the policy documentation")
+	cmd.Flags().StringP("output", "o", "policies.md", "Output location (including filename) for the policy documentation")
 
 	return &cmd
 }
@@ -49,7 +49,7 @@ func runDocCommand(path string) error {
 		return fmt.Errorf("get policy documentation: %w", err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(path, viper.GetString("output")), []byte(policyDocumentation), os.ModePerm)
+	err = ioutil.WriteFile(viper.GetString("output"), []byte(policyDocumentation), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("writing documentation: %w", err)
 	}


### PR DESCRIPTION
## Issue

When writing the documentation to disk, the location always includes the `path` that was used to declare where the `rego` can be found.

This is problematic when the documentation lives in a different directory than the policies themselves, such as a parent level `docs` directory.