### PR TITLE
Fix loading duplicate rule actions

### DIFF
--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -121,18 +121,16 @@ func loadRegoFiles(files []string) ([]File, error) {
 
 func getModuleRulesActions(module *ast.Module) []string {
 	var rulesActions []string
-	var previouslySeenActions []string
 	re := regexp.MustCompile("^\\s*([a-z]+)\\s*\\[\\s*msg")
 	for _, rule := range module.Rules {
 		match := re.FindStringSubmatch(rule.Head.String())
 		if len(match) == 0 {
 			continue
 		}
-		if contains(previouslySeenActions, match[1]) {
+		if contains(rulesActions, match[1]) {
 			continue
 		}
 		rulesActions = append(rulesActions, match[1])
-		previouslySeenActions = append(previouslySeenActions, match[1])
 	}
 	return rulesActions
 }

--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
 )
@@ -120,13 +121,18 @@ func loadRegoFiles(files []string) ([]File, error) {
 
 func getModuleRulesActions(module *ast.Module) []string {
 	var rulesActions []string
+	var previouslySeenActions []string
 	re := regexp.MustCompile("^\\s*([a-z]+)\\s*\\[\\s*msg")
 	for _, rule := range module.Rules {
 		match := re.FindStringSubmatch(rule.Head.String())
 		if len(match) == 0 {
 			continue
 		}
+		if contains(previouslySeenActions, match[1]) {
+			continue
+		}
 		rulesActions = append(rulesActions, match[1])
+		previouslySeenActions = append(previouslySeenActions, match[1])
 	}
 	return rulesActions
 }
@@ -151,4 +157,14 @@ func readFilesContents(filePaths []string) (map[string]string, error) {
 	}
 
 	return filesContents, nil
+}
+
+func contains(collection []string, item string) bool {
+	for _, value := range collection {
+		if strings.EqualFold(value, item) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/rego/rego_test.go
+++ b/internal/rego/rego_test.go
@@ -35,6 +35,7 @@ func TestGetModulesRulesActions(t *testing.T) {
 		{"package test\nviolation[msg] { msg = true }", 1, []string{"violation"}},
 		{"package test\nwarn[msg] { msg = true }", 1, []string{"warn"}},
 		{"package test\nviolation[msg] { msg = true }\nwarn[msg] { msg = true }", 2, []string{"violation", "warn"}},
+		{"package test\nviolation[msg] { msg = true }\nviolation[msg] { msg = true }", 1, []string{"violation"}},
 	}
 
 	for _, test := range rulesActionsTests {
@@ -44,7 +45,7 @@ func TestGetModulesRulesActions(t *testing.T) {
 		}
 
 		if len(regoFile.RulesActions) != test.ruleCount {
-			t.Error("incorrect rule count")
+			t.Error("incorrect rule actions count")
 		}
 
 		if !reflect.DeepEqual(regoFile.RulesActions, test.ruleActions) {


### PR DESCRIPTION
If a rego file contains multiple rules with the same action type (eg: violation) which is a normal practice, Konstraint would load duplicate values into the `RulesActions` field in the struct. This affected the docs generation and made the output from that contain more than needed.