### PR TITLE
Updated rego file load to be sorted via path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,24 @@
 konstraint*
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+## File-based project format:
+*.iws
+*.iml

--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -115,6 +116,10 @@ func loadRegoFiles(files []string) ([]File, error) {
 
 		regoFiles = append(regoFiles, regoFile)
 	}
+
+	sort.Slice(regoFiles, func(i, j int) bool {
+		return regoFiles[i].FilePath < regoFiles[j].FilePath
+	})
 
 	return regoFiles, nil
 }


### PR DESCRIPTION
Attempts to solve: https://github.com/plexsystems/konstraint/pull/20#issuecomment-662272822

_Disclaimer_: still learning golang. had a google to see if there was an ordered map in go, but google suggested not.