### PR TITLE
Add job to workloads library

### DIFF
--- a/examples/deny-containers-latest-tag/template.yaml
+++ b/examples/deny-containers-latest-tag/template.yaml
@@ -70,6 +70,10 @@ spec:
         lower(core.kind) == "deployment"
       }
 
+      is_job {
+        lower(core.kind) == "job"
+      }
+
       is_pod {
         lower(core.kind) == "pod"
       }
@@ -90,6 +94,11 @@ spec:
 
       pods[pod] {
         is_deployment
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        is_job
         pod = core.resource.spec.template
       }
 

--- a/examples/deny-privileged-containers/template.yaml
+++ b/examples/deny-privileged-containers/template.yaml
@@ -70,6 +70,10 @@ spec:
         lower(core.kind) == "deployment"
       }
 
+      is_job {
+        lower(core.kind) == "job"
+      }
+
       is_pod {
         lower(core.kind) == "pod"
       }
@@ -90,6 +94,11 @@ spec:
 
       pods[pod] {
         is_deployment
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        is_job
         pod = core.resource.spec.template
       }
 

--- a/examples/lib/workloads.rego
+++ b/examples/lib/workloads.rego
@@ -14,6 +14,10 @@ is_deployment {
   lower(core.kind) == "deployment"
 }
 
+is_job {
+  lower(core.kind) == "job"
+}
+
 is_pod {
   lower(core.kind) == "pod"
 }
@@ -34,6 +38,11 @@ pods[pod] {
 
 pods[pod] {
   is_deployment
+  pod = core.resource.spec.template
+}
+
+pods[pod] {
+  is_job
   pod = core.resource.spec.template
 }
 

--- a/examples/require-containers-resource-constraints/template.yaml
+++ b/examples/require-containers-resource-constraints/template.yaml
@@ -70,6 +70,10 @@ spec:
         lower(core.kind) == "deployment"
       }
 
+      is_job {
+        lower(core.kind) == "job"
+      }
+
       is_pod {
         lower(core.kind) == "pod"
       }
@@ -90,6 +94,11 @@ spec:
 
       pods[pod] {
         is_deployment
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        is_job
         pod = core.resource.spec.template
       }
 

--- a/test/create/template_DenyContainersLatestTag.yaml
+++ b/test/create/template_DenyContainersLatestTag.yaml
@@ -70,6 +70,10 @@ spec:
         lower(core.kind) == "deployment"
       }
 
+      is_job {
+        lower(core.kind) == "job"
+      }
+
       is_pod {
         lower(core.kind) == "pod"
       }
@@ -90,6 +94,11 @@ spec:
 
       pods[pod] {
         is_deployment
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        is_job
         pod = core.resource.spec.template
       }
 

--- a/test/create/template_DenyPrivilegedContainers.yaml
+++ b/test/create/template_DenyPrivilegedContainers.yaml
@@ -70,6 +70,10 @@ spec:
         lower(core.kind) == "deployment"
       }
 
+      is_job {
+        lower(core.kind) == "job"
+      }
+
       is_pod {
         lower(core.kind) == "pod"
       }
@@ -90,6 +94,11 @@ spec:
 
       pods[pod] {
         is_deployment
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        is_job
         pod = core.resource.spec.template
       }
 

--- a/test/create/template_RequireContainersResourceConstraints.yaml
+++ b/test/create/template_RequireContainersResourceConstraints.yaml
@@ -70,6 +70,10 @@ spec:
         lower(core.kind) == "deployment"
       }
 
+      is_job {
+        lower(core.kind) == "job"
+      }
+
       is_pod {
         lower(core.kind) == "pod"
       }
@@ -90,6 +94,11 @@ spec:
 
       pods[pod] {
         is_deployment
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        is_job
         pod = core.resource.spec.template
       }
 


### PR DESCRIPTION
Noticed this when doing some rework on our kubernetes manifests. Policy was not failing on a Kubernetes Job that had an invalid image registry host specified.