### PR TITLE
Handle carriage returns found in rego policies

### DIFF
--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -185,7 +185,7 @@ func readFilesContents(filePaths []string) (map[string]string, error) {
 			return nil, fmt.Errorf("read file: %w", err)
 		}
 
-		filesContents[filePath] = string(data)
+		filesContents[filePath] = strings.ReplaceAll(string(data), "\r", "")
 	}
 
 	return filesContents, nil


### PR DESCRIPTION
Forced `CRLF` in VSCode to duplicate the issue.
Verified this change leaves the templates/constraints untouched.
Acceptance tests also came back with no modifications.