### PR TITLE
Split lib.workloads into lib.pods and lib.containers

### DIFF
--- a/examples/container-deny-added-caps/src.rego
+++ b/examples/container-deny-added-caps/src.rego
@@ -8,11 +8,11 @@
 package container_deny_added_caps
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 import data.lib.security
 
 violation[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     not security.dropped_capability(container, "all")
     msg = core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
 }

--- a/examples/container-deny-added-caps/template.yaml
+++ b/examples/container-deny-added-caps/template.yaml
@@ -54,7 +54,54 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.security
+
+      dropped_capability(container, cap) {
+        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
+      }
+
+      added_capability(container, cap) {
+        lower(container.securityContext.capabilities.add[_]) == lower(cap)
+      }
+
+      dropped_capability(psp, cap) {
+        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,61 +130,19 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
-      }
-    - |
-      package lib.security
-
-      dropped_capability(container, cap) {
-        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
-      }
-
-      added_capability(container, cap) {
-        lower(container.securityContext.capabilities.add[_]) == lower(cap)
-      }
-
-      dropped_capability(psp, cap) {
-        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
       }
     rego: |
       package container_deny_added_caps
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
       import data.lib.security
 
       violation[msg] {
-          workloads.containers[container]
+          containers.containers[container]
           not security.dropped_capability(container, "all")
           msg = core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
       }

--- a/examples/container-deny-escalation/src.rego
+++ b/examples/container-deny-escalation/src.rego
@@ -6,11 +6,11 @@
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 package container_deny_escalation
 
-import data.lib.workloads
 import data.lib.core
+import data.lib.containers
 
 violation[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     allows_escalation(container)
     msg = core.format(sprintf("%s/%s/%s: Allows priviledge escalation", [core.kind, core.name, container.name]))
 }

--- a/examples/container-deny-escalation/template.yaml
+++ b/examples/container-deny-escalation/template.yaml
@@ -11,60 +11,6 @@ spec:
   targets:
   - libs:
     - |
-      package lib.workloads
-
-      import data.lib.core
-
-      pods[pod] {
-        lower(core.kind) = "statefulset"
-        pod = core.resource.spec.template
-      }
-
-      pods[pod] {
-        lower(core.kind) = "daemonset"
-        pod = core.resource.spec.template
-      }
-
-      pods[pod] {
-        lower(core.kind) = "deployment"
-        pod = core.resource.spec.template
-      }
-
-      pods[pod] {
-        lower(core.kind) = "pod"
-        pod = core.resource
-      }
-
-      pods[pod] {
-        lower(core.kind) = "job"
-        pod = core.resource.spec.template
-      }
-
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
-      volumes[volume] {
-        pods[pod]
-        volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
-      }
-    - |
       package lib.core
 
       default is_gatekeeper = false
@@ -107,14 +53,73 @@ spec:
       missing_field(obj, field) = true {
         not has_field(obj, field)
       }
+    - |
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.pods
+
+      import data.lib.core
+
+      pods[pod] {
+        lower(core.kind) = "statefulset"
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        lower(core.kind) = "daemonset"
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        lower(core.kind) = "deployment"
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        lower(core.kind) = "pod"
+        pod = core.resource
+      }
+
+      pods[pod] {
+        lower(core.kind) = "job"
+        pod = core.resource.spec.template
+      }
+
+      volumes[volume] {
+        pods[pod]
+        volume = pod.spec.volumes[_]
+      }
     rego: |
       package container_deny_escalation
 
-      import data.lib.workloads
       import data.lib.core
+      import data.lib.containers
 
       violation[msg] {
-          workloads.containers[container]
+          containers.containers[container]
           allows_escalation(container)
           msg = core.format(sprintf("%s/%s/%s: Allows priviledge escalation", [core.kind, core.name, container.name]))
       }

--- a/examples/container-deny-latest-tag/src.rego
+++ b/examples/container-deny-latest-tag/src.rego
@@ -1,7 +1,7 @@
 package container_deny_latest_tag
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 
 # @title Images must not use the latest tag
 #
@@ -10,7 +10,7 @@ import data.lib.workloads
 #
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   has_latest_tag(container)
 
   msg := core.format(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]))

--- a/examples/container-deny-latest-tag/template.yaml
+++ b/examples/container-deny-latest-tag/template.yaml
@@ -54,7 +54,32 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +108,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package container_deny_latest_tag
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
 
       violation[msg] {
-        workloads.containers[container]
+        containers.containers[container]
         has_latest_tag(container)
 
         msg := core.format(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]))

--- a/examples/container-deny-privileged/src.rego
+++ b/examples/container-deny-privileged/src.rego
@@ -1,7 +1,7 @@
 package container_deny_privileged
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 import data.lib.security
 
 # @title Containers must not run as privileged
@@ -13,7 +13,7 @@ import data.lib.security
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   is_privileged(container)
 
   msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))

--- a/examples/container-deny-privileged/template.yaml
+++ b/examples/container-deny-privileged/template.yaml
@@ -54,7 +54,54 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.security
+
+      dropped_capability(container, cap) {
+        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
+      }
+
+      added_capability(container, cap) {
+        lower(container.securityContext.capabilities.add[_]) == lower(cap)
+      }
+
+      dropped_capability(psp, cap) {
+        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,62 +130,20 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
-      }
-    - |
-      package lib.security
-
-      dropped_capability(container, cap) {
-        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
-      }
-
-      added_capability(container, cap) {
-        lower(container.securityContext.capabilities.add[_]) == lower(cap)
-      }
-
-      dropped_capability(psp, cap) {
-        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
       }
     rego: |
       package container_deny_privileged
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
       import data.lib.security
 
 
       violation[msg] {
-        workloads.containers[container]
+        containers.containers[container]
         is_privileged(container)
 
         msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))

--- a/examples/container-deny-without-resource-constraints/src.rego
+++ b/examples/container-deny-without-resource-constraints/src.rego
@@ -1,7 +1,7 @@
 package container_deny_without_resource_constraints
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 
 # @title Containers must define resource constraints
 #
@@ -10,7 +10,7 @@ import data.lib.workloads
 #
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   not container_resources_provided(container)
 
   msg := core.format(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]))

--- a/examples/container-deny-without-resource-constraints/template.yaml
+++ b/examples/container-deny-without-resource-constraints/template.yaml
@@ -54,7 +54,32 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +108,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package container_deny_without_resource_constraints
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
 
       violation[msg] {
-        workloads.containers[container]
+        containers.containers[container]
         not container_resources_provided(container)
 
         msg := core.format(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]))

--- a/examples/container-warn-no-ro-fs/src.rego
+++ b/examples/container-warn-no-ro-fs/src.rego
@@ -6,11 +6,11 @@
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 package container_warn_no_ro_fs
 
-import data.lib.workloads
+import data.lib.containers
 import data.lib.core
 
 warn[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     no_read_only_filesystem(container)
     msg = core.format(sprintf("%s/%s/%s: Is not using a read only root filesystem", [core.kind, core.name, container.name]))
 }

--- a/examples/lib/containers.rego
+++ b/examples/lib/containers.rego
@@ -1,0 +1,24 @@
+package lib.containers
+
+import data.lib.core
+import data.lib.pods
+
+pod_containers(pod) = all_containers {
+  keys = {"containers", "initContainers"}
+  all_containers = [c | keys[k]; c = pod.spec[k][_]]
+}
+
+containers[container] {
+  pods.pods[pod]
+  all_containers = pod_containers(pod)
+  container = all_containers[_]
+}
+
+containers[container] {
+  all_containers = pod_containers(core.resource)
+  container = all_containers[_]
+}
+
+is_workload {
+  containers[_]
+}

--- a/examples/lib/pods.rego
+++ b/examples/lib/pods.rego
@@ -1,4 +1,4 @@
-package lib.workloads
+package lib.pods
 
 import data.lib.core
 
@@ -27,27 +27,7 @@ pods[pod] {
   pod = core.resource.spec.template
 }
 
-pod_containers(pod) = all_containers {
-  keys = {"containers", "initContainers"}
-  all_containers = [c | keys[k]; c = pod.spec[k][_]]
-}
-
-containers[container] {
-  pods[pod]
-  all_containers = pod_containers(pod)
-  container = all_containers[_]
-}
-
-containers[container] {
-  all_containers = pod_containers(core.resource)
-  container = all_containers[_]
-}
-
 volumes[volume] {
   pods[pod]
   volume = pod.spec.volumes[_]
-}
-
-is_workload {
-  containers[_]
 }

--- a/examples/pod-deny-host-alias/src.rego
+++ b/examples/pod-deny-host-alias/src.rego
@@ -7,10 +7,10 @@
 package pod_deny_host_alias
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostAliases
     msg = core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
 }

--- a/examples/pod-deny-host-alias/template.yaml
+++ b/examples/pod-deny-host-alias/template.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_alias
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostAliases
           msg = core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
       }

--- a/examples/pod-deny-host-ipc/src.rego
+++ b/examples/pod-deny-host-ipc/src.rego
@@ -7,10 +7,10 @@
 package pod_deny_host_ipc
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostIPC
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
 }

--- a/examples/pod-deny-host-ipc/template.yaml
+++ b/examples/pod-deny-host-ipc/template.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_ipc
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostIPC
           msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
       }

--- a/examples/pod-deny-host-network/src.rego
+++ b/examples/pod-deny-host-network/src.rego
@@ -7,10 +7,10 @@
 package pod_deny_host_network
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostNetwork
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
 }

--- a/examples/pod-deny-host-network/template.yaml
+++ b/examples/pod-deny-host-network/template.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_network
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostNetwork
           msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
       }

--- a/examples/pod-deny-host-pid/src.rego
+++ b/examples/pod-deny-host-pid/src.rego
@@ -8,10 +8,10 @@
 package pod_deny_host_pid
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostPID
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
 }

--- a/examples/pod-deny-host-pid/template.yaml
+++ b/examples/pod-deny-host-pid/template.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_pid
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostPID
           msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
       }

--- a/examples/pod-deny-without-runasnonroot/src.rego
+++ b/examples/pod-deny-without-runasnonroot/src.rego
@@ -6,11 +6,11 @@
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 package pod_deny_without_runasnonroot
 
-import data.lib.workloads
+import data.lib.pods
 import data.lib.core
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     not pod.spec.securityContext.runAsNonRoot
     msg = core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
 }

--- a/examples/pod-deny-without-runasnonroot/template.yaml
+++ b/examples/pod-deny-without-runasnonroot/template.yaml
@@ -11,7 +11,7 @@ spec:
   targets:
   - libs:
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -40,29 +40,9 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     - |
       package lib.core
@@ -110,11 +90,11 @@ spec:
     rego: |
       package pod_deny_without_runasnonroot
 
-      import data.lib.workloads
+      import data.lib.pods
       import data.lib.core
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           not pod.spec.securityContext.runAsNonRoot
           msg = core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
       }

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -43,11 +43,11 @@ outside of Kubernetes controller namespaces.
 package container_deny_added_caps
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 import data.lib.security
 
 violation[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     not security.dropped_capability(container, "all")
     msg = core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
 }
@@ -70,11 +70,11 @@ As such, they are not allowed.
 ```rego
 package container_deny_escalation
 
-import data.lib.workloads
 import data.lib.core
+import data.lib.containers
 
 violation[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     allows_escalation(container)
     msg = core.format(sprintf("%s/%s/%s: Allows priviledge escalation", [core.kind, core.name, container.name]))
 }
@@ -106,10 +106,10 @@ we can have higher confidence that our applications are immutable and do not cha
 package container_deny_latest_tag
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   has_latest_tag(container)
 
   msg := core.format(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]))
@@ -143,12 +143,12 @@ to obtain the same effect are not allowed.
 package container_deny_privileged
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 import data.lib.security
 
 
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   is_privileged(container)
 
   msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))
@@ -181,10 +181,10 @@ and potentially starve other applications that need to run.
 package container_deny_without_resource_constraints
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   not container_resources_provided(container)
 
   msg := core.format(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]))
@@ -216,10 +216,10 @@ redirect traffic to malicious servers.
 package pod_deny_host_alias
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostAliases
     msg = core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
 }
@@ -243,10 +243,10 @@ the other containers, breaking that security boundary.
 package pod_deny_host_ipc
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostIPC
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
 }
@@ -270,10 +270,10 @@ access and tamper with traffic the pod should not have access to.
 package pod_deny_host_network
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostNetwork
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
 }
@@ -298,10 +298,10 @@ boundary.
 package pod_deny_host_pid
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostPID
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
 }
@@ -324,11 +324,11 @@ to root on the node. As such, they are not allowed.
 ```rego
 package pod_deny_without_runasnonroot
 
-import data.lib.workloads
+import data.lib.pods
 import data.lib.core
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     not pod.spec.securityContext.runAsNonRoot
     msg = core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
 }
@@ -581,11 +581,11 @@ important to make the root filesystem read-only.
 ```rego
 package container_warn_no_ro_fs
 
-import data.lib.workloads
+import data.lib.containers
 import data.lib.core
 
 warn[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     no_read_only_filesystem(container)
     msg = core.format(sprintf("%s/%s/%s: Is not using a read only root filesystem", [core.kind, core.name, container.name]))
 }

--- a/test/create/template_ContainerDenyAddedCaps.yaml
+++ b/test/create/template_ContainerDenyAddedCaps.yaml
@@ -54,7 +54,54 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.security
+
+      dropped_capability(container, cap) {
+        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
+      }
+
+      added_capability(container, cap) {
+        lower(container.securityContext.capabilities.add[_]) == lower(cap)
+      }
+
+      dropped_capability(psp, cap) {
+        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,61 +130,19 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
-      }
-    - |
-      package lib.security
-
-      dropped_capability(container, cap) {
-        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
-      }
-
-      added_capability(container, cap) {
-        lower(container.securityContext.capabilities.add[_]) == lower(cap)
-      }
-
-      dropped_capability(psp, cap) {
-        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
       }
     rego: |
       package container_deny_added_caps
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
       import data.lib.security
 
       violation[msg] {
-          workloads.containers[container]
+          containers.containers[container]
           not security.dropped_capability(container, "all")
           msg = core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
       }

--- a/test/create/template_ContainerDenyEscalation.yaml
+++ b/test/create/template_ContainerDenyEscalation.yaml
@@ -11,60 +11,6 @@ spec:
   targets:
   - libs:
     - |
-      package lib.workloads
-
-      import data.lib.core
-
-      pods[pod] {
-        lower(core.kind) = "statefulset"
-        pod = core.resource.spec.template
-      }
-
-      pods[pod] {
-        lower(core.kind) = "daemonset"
-        pod = core.resource.spec.template
-      }
-
-      pods[pod] {
-        lower(core.kind) = "deployment"
-        pod = core.resource.spec.template
-      }
-
-      pods[pod] {
-        lower(core.kind) = "pod"
-        pod = core.resource
-      }
-
-      pods[pod] {
-        lower(core.kind) = "job"
-        pod = core.resource.spec.template
-      }
-
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
-      volumes[volume] {
-        pods[pod]
-        volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
-      }
-    - |
       package lib.core
 
       default is_gatekeeper = false
@@ -107,14 +53,73 @@ spec:
       missing_field(obj, field) = true {
         not has_field(obj, field)
       }
+    - |
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.pods
+
+      import data.lib.core
+
+      pods[pod] {
+        lower(core.kind) = "statefulset"
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        lower(core.kind) = "daemonset"
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        lower(core.kind) = "deployment"
+        pod = core.resource.spec.template
+      }
+
+      pods[pod] {
+        lower(core.kind) = "pod"
+        pod = core.resource
+      }
+
+      pods[pod] {
+        lower(core.kind) = "job"
+        pod = core.resource.spec.template
+      }
+
+      volumes[volume] {
+        pods[pod]
+        volume = pod.spec.volumes[_]
+      }
     rego: |
       package container_deny_escalation
 
-      import data.lib.workloads
       import data.lib.core
+      import data.lib.containers
 
       violation[msg] {
-          workloads.containers[container]
+          containers.containers[container]
           allows_escalation(container)
           msg = core.format(sprintf("%s/%s/%s: Allows priviledge escalation", [core.kind, core.name, container.name]))
       }

--- a/test/create/template_ContainerDenyLatestTag.yaml
+++ b/test/create/template_ContainerDenyLatestTag.yaml
@@ -54,7 +54,32 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +108,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package container_deny_latest_tag
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
 
       violation[msg] {
-        workloads.containers[container]
+        containers.containers[container]
         has_latest_tag(container)
 
         msg := core.format(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]))

--- a/test/create/template_ContainerDenyPrivileged.yaml
+++ b/test/create/template_ContainerDenyPrivileged.yaml
@@ -54,7 +54,54 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.security
+
+      dropped_capability(container, cap) {
+        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
+      }
+
+      added_capability(container, cap) {
+        lower(container.securityContext.capabilities.add[_]) == lower(cap)
+      }
+
+      dropped_capability(psp, cap) {
+        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,62 +130,20 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
-      }
-    - |
-      package lib.security
-
-      dropped_capability(container, cap) {
-        lower(container.securityContext.capabilities.drop[_]) == lower(cap)
-      }
-
-      added_capability(container, cap) {
-        lower(container.securityContext.capabilities.add[_]) == lower(cap)
-      }
-
-      dropped_capability(psp, cap) {
-        lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.allowedCapabilities[_]) == lower(cap)
-      }
-
-      added_capability(psp, cap) {
-        lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
       }
     rego: |
       package container_deny_privileged
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
       import data.lib.security
 
 
       violation[msg] {
-        workloads.containers[container]
+        containers.containers[container]
         is_privileged(container)
 
         msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))

--- a/test/create/template_ContainerDenyWithoutResourceConstraints.yaml
+++ b/test/create/template_ContainerDenyWithoutResourceConstraints.yaml
@@ -54,7 +54,32 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.containers
+
+      import data.lib.core
+      import data.lib.pods
+
+      pod_containers(pod) = all_containers {
+        keys = {"containers", "initContainers"}
+        all_containers = [c | keys[k]; c = pod.spec[k][_]]
+      }
+
+      containers[container] {
+        pods.pods[pod]
+        all_containers = pod_containers(pod)
+        container = all_containers[_]
+      }
+
+      containers[container] {
+        all_containers = pod_containers(core.resource)
+        container = all_containers[_]
+      }
+
+      is_workload {
+        containers[_]
+      }
+    - |
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +108,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package container_deny_without_resource_constraints
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.containers
 
       violation[msg] {
-        workloads.containers[container]
+        containers.containers[container]
         not container_resources_provided(container)
 
         msg := core.format(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]))

--- a/test/create/template_PodDenyHostAlias.yaml
+++ b/test/create/template_PodDenyHostAlias.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_alias
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostAliases
           msg = core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
       }

--- a/test/create/template_PodDenyHostIpc.yaml
+++ b/test/create/template_PodDenyHostIpc.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_ipc
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostIPC
           msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
       }

--- a/test/create/template_PodDenyHostNetwork.yaml
+++ b/test/create/template_PodDenyHostNetwork.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_network
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostNetwork
           msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
       }

--- a/test/create/template_PodDenyHostPid.yaml
+++ b/test/create/template_PodDenyHostPid.yaml
@@ -54,7 +54,7 @@ spec:
         not has_field(obj, field)
       }
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -83,38 +83,18 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     rego: |
       package pod_deny_host_pid
 
       import data.lib.core
-      import data.lib.workloads
+      import data.lib.pods
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           pod.spec.hostPID
           msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
       }

--- a/test/create/template_PodDenyWithoutRunasnonroot.yaml
+++ b/test/create/template_PodDenyWithoutRunasnonroot.yaml
@@ -11,7 +11,7 @@ spec:
   targets:
   - libs:
     - |
-      package lib.workloads
+      package lib.pods
 
       import data.lib.core
 
@@ -40,29 +40,9 @@ spec:
         pod = core.resource.spec.template
       }
 
-      pod_containers(pod) = all_containers {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-      }
-
-      containers[container] {
-        pods[pod]
-        all_containers = pod_containers(pod)
-        container = all_containers[_]
-      }
-
-      containers[container] {
-        all_containers = pod_containers(core.resource)
-        container = all_containers[_]
-      }
-
       volumes[volume] {
         pods[pod]
         volume = pod.spec.volumes[_]
-      }
-
-      is_workload {
-        containers[_]
       }
     - |
       package lib.core
@@ -110,11 +90,11 @@ spec:
     rego: |
       package pod_deny_without_runasnonroot
 
-      import data.lib.workloads
+      import data.lib.pods
       import data.lib.core
 
       violation[msg] {
-          workloads.pods[pod]
+          pods.pods[pod]
           not pod.spec.securityContext.runAsNonRoot
           msg = core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
       }

--- a/test/doc/expected.md
+++ b/test/doc/expected.md
@@ -43,11 +43,11 @@ outside of Kubernetes controller namespaces.
 package container_deny_added_caps
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 import data.lib.security
 
 violation[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     not security.dropped_capability(container, "all")
     msg = core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
 }
@@ -70,11 +70,11 @@ As such, they are not allowed.
 ```rego
 package container_deny_escalation
 
-import data.lib.workloads
 import data.lib.core
+import data.lib.containers
 
 violation[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     allows_escalation(container)
     msg = core.format(sprintf("%s/%s/%s: Allows priviledge escalation", [core.kind, core.name, container.name]))
 }
@@ -106,10 +106,10 @@ we can have higher confidence that our applications are immutable and do not cha
 package container_deny_latest_tag
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   has_latest_tag(container)
 
   msg := core.format(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]))
@@ -143,12 +143,12 @@ to obtain the same effect are not allowed.
 package container_deny_privileged
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 import data.lib.security
 
 
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   is_privileged(container)
 
   msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))
@@ -181,10 +181,10 @@ and potentially starve other applications that need to run.
 package container_deny_without_resource_constraints
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.containers
 
 violation[msg] {
-  workloads.containers[container]
+  containers.containers[container]
   not container_resources_provided(container)
 
   msg := core.format(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]))
@@ -216,10 +216,10 @@ redirect traffic to malicious servers.
 package pod_deny_host_alias
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostAliases
     msg = core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
 }
@@ -243,10 +243,10 @@ the other containers, breaking that security boundary.
 package pod_deny_host_ipc
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostIPC
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
 }
@@ -270,10 +270,10 @@ access and tamper with traffic the pod should not have access to.
 package pod_deny_host_network
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostNetwork
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
 }
@@ -298,10 +298,10 @@ boundary.
 package pod_deny_host_pid
 
 import data.lib.core
-import data.lib.workloads
+import data.lib.pods
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     pod.spec.hostPID
     msg = core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
 }
@@ -324,11 +324,11 @@ to root on the node. As such, they are not allowed.
 ```rego
 package pod_deny_without_runasnonroot
 
-import data.lib.workloads
+import data.lib.pods
 import data.lib.core
 
 violation[msg] {
-    workloads.pods[pod]
+    pods.pods[pod]
     not pod.spec.securityContext.runAsNonRoot
     msg = core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
 }
@@ -581,11 +581,11 @@ important to make the root filesystem read-only.
 ```rego
 package container_warn_no_ro_fs
 
-import data.lib.workloads
+import data.lib.containers
 import data.lib.core
 
 warn[msg] {
-    workloads.containers[container]
+    containers.containers[container]
     no_read_only_filesystem(container)
     msg = core.format(sprintf("%s/%s/%s: Is not using a read only root filesystem", [core.kind, core.name, container.name]))
 }


### PR DESCRIPTION
By splitting this, we can further reduce the size of our generated `ConstraintTemplate`s because Pod related policies no longer include unnecessary container related functions.

**This is a breaking change for anyone using the `lib.workloads` library in their policies**