### PR TITLE
Sanitize rego for documentation

### DIFF
--- a/examples/policies.md
+++ b/examples/policies.md
@@ -32,11 +32,9 @@
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
-
 ### Rego
 
 ```rego
@@ -52,7 +50,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
 }
-
 ```
 _source: [container-deny-added-caps](container-deny-added-caps)_
 
@@ -62,10 +59,8 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -88,7 +83,6 @@ allows_escalation(c) {
 allows_escalation(c) {
     core.missing_field(c.securityContext, "allowPrivilegeEscalation")
 }
-
 ```
 _source: [container-deny-escalation](container-deny-escalation)_
 
@@ -98,10 +92,8 @@ _source: [container-deny-escalation](container-deny-escalation)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Using the latest tag on images can cause unexpected problems in production. By specifing a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
-
 ### Rego
 
 ```rego
@@ -124,7 +116,6 @@ has_latest_tag(c) {
 has_latest_tag(c) {
     contains(c.image, ":") == false
 }
-
 ```
 _source: [container-deny-latest-tag](container-deny-latest-tag)_
 
@@ -134,11 +125,9 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
 to obtain the same effect are not allowed.
-
 ### Rego
 
 ```rego
@@ -163,7 +152,6 @@ is_privileged(container) {
 is_privileged(container) {
   security.added_capability(container, "CAP_SYS_ADMIN")
 }
-
 ```
 _source: [container-deny-privileged](container-deny-privileged)_
 
@@ -173,10 +161,8 @@ _source: [container-deny-privileged](container-deny-privileged)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Resource constraints on containers ensure that a given workload does not take up more resources than it required
 and potentially starve other applications that need to run.
-
 ### Rego
 
 ```rego
@@ -198,7 +184,6 @@ container_resources_provided(container) {
     container.resources.limits.cpu
     container.resources.limits.memory
 }
-
 ```
 _source: [container-deny-without-resource-constraints](container-deny-without-resource-constraints)_
 
@@ -208,10 +193,8 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
-
 ### Rego
 
 ```rego
@@ -226,7 +209,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [pod-deny-host-alias](pod-deny-host-alias)_
 
@@ -236,10 +218,8 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
-
 ### Rego
 
 ```rego
@@ -254,7 +234,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
@@ -264,10 +243,8 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
-
 ### Rego
 
 ```rego
@@ -282,7 +259,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [pod-deny-host-network](pod-deny-host-network)_
 
@@ -292,11 +268,9 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that can acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 ### Rego
 
 ```rego
@@ -311,7 +285,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
@@ -321,10 +294,8 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -339,7 +310,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 
@@ -349,11 +319,9 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
-
 ### Rego
 
 ```rego
@@ -369,7 +337,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]))
 }
-
 ```
 _source: [psp-deny-added-caps](psp-deny-added-caps)_
 
@@ -379,10 +346,8 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -405,7 +370,6 @@ allows_escalation(p) {
 allows_escalation(p) {
     core.missing_field(p.spec, "allowPrivilegeEscalation")
 }
-
 ```
 _source: [psp-deny-escalation](psp-deny-escalation)_
 
@@ -415,10 +379,8 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
-
 ### Rego
 
 ```rego
@@ -433,7 +395,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for managing host aliases", [core.kind, core.name]))
 }
-
 ```
 _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
@@ -443,10 +404,8 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to to access the host IPC can read memory of
 the other containers, breaking that security boundary.
-
 ### Rego
 
 ```rego
@@ -461,7 +420,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]))
 }
-
 ```
 _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 
@@ -471,11 +429,9 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 ### Rego
 
 ```rego
@@ -490,7 +446,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for accessing the host network", [core.kind, core.name]))
 }
-
 ```
 _source: [psp-deny-host-network](psp-deny-host-network)_
 
@@ -500,11 +455,9 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 ### Rego
 
 ```rego
@@ -518,7 +471,6 @@ violation[msg] {
     psp.spec.hostPID
     msg = core.format(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]))
 }
-
 ```
 _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
@@ -528,10 +480,8 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -546,7 +496,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for privileged workloads", [core.kind, core.name]))
 }
-
 ```
 _source: [psp-deny-privileged](psp-deny-privileged)_
 
@@ -555,7 +504,6 @@ _source: [psp-deny-privileged](psp-deny-privileged)_
 **Severity:** warn
 
 **Resources:** apps/DaemonSet apps/Deployment
-
 
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
@@ -575,7 +523,6 @@ warn[msg] {
     
     msg := core.format(sprintf("API extensions/v1beta1 for %s has been deprecated, use apps/v1 instead.", [core.kind]))
 }
-
 ```
 _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 
@@ -584,7 +531,6 @@ _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 **Severity:** warn
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
@@ -612,7 +558,6 @@ no_read_only_filesystem(container) {
 no_read_only_filesystem(container) {
     core.missing_field(container.securityContext, "readOnlyRootFilesystem")
 }
-
 ```
 _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 
@@ -621,7 +566,6 @@ _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 **Severity:** warn
 
 **Resources:** policy/PodSecurityPolicy
-
 
 Allowping pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
@@ -648,6 +592,5 @@ no_read_only_filesystem(psp) {
 no_read_only_filesystem(psp) {
     not psp.spec.readOnlyRootFilesystem
 }
-
 ```
 _source: [psp-warn-no-ro-fs](psp-warn-no-ro-fs)_

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -35,6 +35,7 @@
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
+
 ### Rego
 
 ```rego
@@ -51,6 +52,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
 }
 ```
+
 _source: [container-deny-added-caps](container-deny-added-caps)_
 
 ## Containers must not allow for privilege escalation
@@ -61,6 +63,7 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -84,6 +87,7 @@ allows_escalation(c) {
     core.missing_field(c.securityContext, "allowPrivilegeEscalation")
 }
 ```
+
 _source: [container-deny-escalation](container-deny-escalation)_
 
 ## Images must not use the latest tag
@@ -94,6 +98,7 @@ _source: [container-deny-escalation](container-deny-escalation)_
 
 Using the latest tag on images can cause unexpected problems in production. By specifing a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
+
 ### Rego
 
 ```rego
@@ -117,6 +122,7 @@ has_latest_tag(c) {
     contains(c.image, ":") == false
 }
 ```
+
 _source: [container-deny-latest-tag](container-deny-latest-tag)_
 
 ## Containers must not run as privileged
@@ -128,6 +134,7 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
 to obtain the same effect are not allowed.
+
 ### Rego
 
 ```rego
@@ -153,6 +160,7 @@ is_privileged(container) {
   security.added_capability(container, "CAP_SYS_ADMIN")
 }
 ```
+
 _source: [container-deny-privileged](container-deny-privileged)_
 
 ## Containers must define resource constraints
@@ -163,6 +171,7 @@ _source: [container-deny-privileged](container-deny-privileged)_
 
 Resource constraints on containers ensure that a given workload does not take up more resources than it required
 and potentially starve other applications that need to run.
+
 ### Rego
 
 ```rego
@@ -185,6 +194,7 @@ container_resources_provided(container) {
     container.resources.limits.memory
 }
 ```
+
 _source: [container-deny-without-resource-constraints](container-deny-without-resource-constraints)_
 
 ## Pods must not have access to the host aliases
@@ -195,6 +205,7 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 
 Pods that can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
+
 ### Rego
 
 ```rego
@@ -210,6 +221,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [pod-deny-host-alias](pod-deny-host-alias)_
 
 ## Pods must not run with access to the host IPC
@@ -220,6 +232,7 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
+
 ### Rego
 
 ```rego
@@ -235,6 +248,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
 ## Pods must not run with access to the host networking
@@ -245,6 +259,7 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
+
 ### Rego
 
 ```rego
@@ -260,6 +275,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [pod-deny-host-network](pod-deny-host-network)_
 
 ## Pods must not run with access to the host PID namespace
@@ -271,6 +287,7 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 Pods that can acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
+
 ### Rego
 
 ```rego
@@ -286,6 +303,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
 ## Pods must run as non-root
@@ -296,6 +314,7 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -311,6 +330,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 
 ## PodSecurityPolicies must require all capabilities are dropped
@@ -322,6 +342,7 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
+
 ### Rego
 
 ```rego
@@ -338,6 +359,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]))
 }
 ```
+
 _source: [psp-deny-added-caps](psp-deny-added-caps)_
 
 ## PodSecurityPolicies must not allow privileged escalation
@@ -348,6 +370,7 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -371,6 +394,7 @@ allows_escalation(p) {
     core.missing_field(p.spec, "allowPrivilegeEscalation")
 }
 ```
+
 _source: [psp-deny-escalation](psp-deny-escalation)_
 
 ## PodSecurityPolicies must not allow access to the host aliases
@@ -381,6 +405,7 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
+
 ### Rego
 
 ```rego
@@ -396,6 +421,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for managing host aliases", [core.kind, core.name]))
 }
 ```
+
 _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
 ## PodSecurityPolicies must not allow access to the host IPC
@@ -406,6 +432,7 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
 Allowing pods to to access the host IPC can read memory of
 the other containers, breaking that security boundary.
+
 ### Rego
 
 ```rego
@@ -421,6 +448,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]))
 }
 ```
+
 _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 
 ## PodSecurityPolicies must not allow access to the host network
@@ -432,6 +460,7 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
+
 ### Rego
 
 ```rego
@@ -447,6 +476,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for accessing the host network", [core.kind, core.name]))
 }
 ```
+
 _source: [psp-deny-host-network](psp-deny-host-network)_
 
 ## PodSecurityPolicies must not allow access to the host PID namespace
@@ -458,6 +488,7 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
+
 ### Rego
 
 ```rego
@@ -472,6 +503,7 @@ violation[msg] {
     msg = core.format(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]))
 }
 ```
+
 _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
 ## PodSecurityPolicies must require containers to not run as privileged
@@ -482,6 +514,7 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -497,6 +530,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for privileged workloads", [core.kind, core.name]))
 }
 ```
+
 _source: [psp-deny-privileged](psp-deny-privileged)_
 
 ## Deprecated Deployment and DaemonSet API

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -136,7 +136,7 @@ func runDocCommand(path string) error {
 		documentContents += "\n\n"
 
 		documentContents += document.Header.Description
-		documentContents += "\n"
+		documentContents += "\n\n"
 
 		documentContents += "### Rego"
 		documentContents += "\n\n"
@@ -189,9 +189,9 @@ func getDocumentation(path string, severity string, outputDirectory string) ([]D
 
 		document := Document{
 			Header:   header,
-			Severity: severity,
-			URL:      relDir,
-			Rego:     regoWithoutComments,
+			Severity: trimContent(severity),
+			URL:      trimContent(relDir),
+			Rego:     trimContent(regoWithoutComments),
 		}
 
 		documents = append(documents, document)
@@ -223,15 +223,19 @@ func getHeader(comments []string) (Header, error) {
 		description += comment + "\n"
 	}
 
-	description = strings.TrimSuffix(description, "\n")
-
 	header := Header{
-		Title:       strings.Trim(title, " "),
-		Description: strings.Trim(description, " "),
-		Resources:   strings.Trim(resources, " "),
+		Title:       trimContent(title),
+		Description: trimContent(description),
+		Resources:   trimContent(resources),
 	}
 
 	return header, nil
+}
+
+func trimContent(content string) string {
+	content = strings.Trim(content, " ")
+	content = strings.Trim(content, "\n")
+	return content
 }
 
 func getRegoWithoutComments(rego string) string {

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -107,7 +107,7 @@ func runDocCommand(path string) error {
 		documentContents += "\n\n"
 
 		documentContents += document.Header.Description
-		documentContents += "\n"
+		documentContents += "\n\n"
 
 		documentContents += "### Rego"
 		documentContents += "\n\n"
@@ -119,7 +119,7 @@ func runDocCommand(path string) error {
 		documentContents += "\n"
 
 		documentContents += "```"
-		documentContents += "\n"
+		documentContents += "\n\n"
 
 		documentContents += "_source: [" + document.URL + "](" + document.URL + ")_"
 		documentContents += "\n\n"

--- a/test/doc/expected.md
+++ b/test/doc/expected.md
@@ -32,11 +32,9 @@
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
-
 ### Rego
 
 ```rego
@@ -52,7 +50,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
 }
-
 ```
 _source: [../../examples/container-deny-added-caps](../../examples/container-deny-added-caps)_
 
@@ -62,10 +59,8 @@ _source: [../../examples/container-deny-added-caps](../../examples/container-den
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -88,7 +83,6 @@ allows_escalation(c) {
 allows_escalation(c) {
     core.missing_field(c.securityContext, "allowPrivilegeEscalation")
 }
-
 ```
 _source: [../../examples/container-deny-escalation](../../examples/container-deny-escalation)_
 
@@ -98,10 +92,8 @@ _source: [../../examples/container-deny-escalation](../../examples/container-den
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Using the latest tag on images can cause unexpected problems in production. By specifing a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
-
 ### Rego
 
 ```rego
@@ -124,7 +116,6 @@ has_latest_tag(c) {
 has_latest_tag(c) {
     contains(c.image, ":") == false
 }
-
 ```
 _source: [../../examples/container-deny-latest-tag](../../examples/container-deny-latest-tag)_
 
@@ -134,11 +125,9 @@ _source: [../../examples/container-deny-latest-tag](../../examples/container-den
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
 to obtain the same effect are not allowed.
-
 ### Rego
 
 ```rego
@@ -163,7 +152,6 @@ is_privileged(container) {
 is_privileged(container) {
   security.added_capability(container, "CAP_SYS_ADMIN")
 }
-
 ```
 _source: [../../examples/container-deny-privileged](../../examples/container-deny-privileged)_
 
@@ -173,10 +161,8 @@ _source: [../../examples/container-deny-privileged](../../examples/container-den
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Resource constraints on containers ensure that a given workload does not take up more resources than it required
 and potentially starve other applications that need to run.
-
 ### Rego
 
 ```rego
@@ -198,7 +184,6 @@ container_resources_provided(container) {
     container.resources.limits.cpu
     container.resources.limits.memory
 }
-
 ```
 _source: [../../examples/container-deny-without-resource-constraints](../../examples/container-deny-without-resource-constraints)_
 
@@ -208,10 +193,8 @@ _source: [../../examples/container-deny-without-resource-constraints](../../exam
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
-
 ### Rego
 
 ```rego
@@ -226,7 +209,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [../../examples/pod-deny-host-alias](../../examples/pod-deny-host-alias)_
 
@@ -236,10 +218,8 @@ _source: [../../examples/pod-deny-host-alias](../../examples/pod-deny-host-alias
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
-
 ### Rego
 
 ```rego
@@ -254,7 +234,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [../../examples/pod-deny-host-ipc](../../examples/pod-deny-host-ipc)_
 
@@ -264,10 +243,8 @@ _source: [../../examples/pod-deny-host-ipc](../../examples/pod-deny-host-ipc)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
-
 ### Rego
 
 ```rego
@@ -282,7 +259,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [../../examples/pod-deny-host-network](../../examples/pod-deny-host-network)_
 
@@ -292,11 +268,9 @@ _source: [../../examples/pod-deny-host-network](../../examples/pod-deny-host-net
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods that can acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 ### Rego
 
 ```rego
@@ -311,7 +285,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [../../examples/pod-deny-host-pid](../../examples/pod-deny-host-pid)_
 
@@ -321,10 +294,8 @@ _source: [../../examples/pod-deny-host-pid](../../examples/pod-deny-host-pid)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -339,7 +310,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
 }
-
 ```
 _source: [../../examples/pod-deny-without-runasnonroot](../../examples/pod-deny-without-runasnonroot)_
 
@@ -349,11 +319,9 @@ _source: [../../examples/pod-deny-without-runasnonroot](../../examples/pod-deny-
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
-
 ### Rego
 
 ```rego
@@ -369,7 +337,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]))
 }
-
 ```
 _source: [../../examples/psp-deny-added-caps](../../examples/psp-deny-added-caps)_
 
@@ -379,10 +346,8 @@ _source: [../../examples/psp-deny-added-caps](../../examples/psp-deny-added-caps
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -405,7 +370,6 @@ allows_escalation(p) {
 allows_escalation(p) {
     core.missing_field(p.spec, "allowPrivilegeEscalation")
 }
-
 ```
 _source: [../../examples/psp-deny-escalation](../../examples/psp-deny-escalation)_
 
@@ -415,10 +379,8 @@ _source: [../../examples/psp-deny-escalation](../../examples/psp-deny-escalation
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
-
 ### Rego
 
 ```rego
@@ -433,7 +395,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for managing host aliases", [core.kind, core.name]))
 }
-
 ```
 _source: [../../examples/psp-deny-host-alias](../../examples/psp-deny-host-alias)_
 
@@ -443,10 +404,8 @@ _source: [../../examples/psp-deny-host-alias](../../examples/psp-deny-host-alias
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to to access the host IPC can read memory of
 the other containers, breaking that security boundary.
-
 ### Rego
 
 ```rego
@@ -461,7 +420,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]))
 }
-
 ```
 _source: [../../examples/psp-deny-host-ipc](../../examples/psp-deny-host-ipc)_
 
@@ -471,11 +429,9 @@ _source: [../../examples/psp-deny-host-ipc](../../examples/psp-deny-host-ipc)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 ### Rego
 
 ```rego
@@ -490,7 +446,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for accessing the host network", [core.kind, core.name]))
 }
-
 ```
 _source: [../../examples/psp-deny-host-network](../../examples/psp-deny-host-network)_
 
@@ -500,11 +455,9 @@ _source: [../../examples/psp-deny-host-network](../../examples/psp-deny-host-net
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 ### Rego
 
 ```rego
@@ -518,7 +471,6 @@ violation[msg] {
     psp.spec.hostPID
     msg = core.format(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]))
 }
-
 ```
 _source: [../../examples/psp-deny-host-pid](../../examples/psp-deny-host-pid)_
 
@@ -528,10 +480,8 @@ _source: [../../examples/psp-deny-host-pid](../../examples/psp-deny-host-pid)_
 
 **Resources:** policy/PodSecurityPolicy
 
-
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 ### Rego
 
 ```rego
@@ -546,7 +496,6 @@ violation[msg] {
 
     msg := core.format(sprintf("%s/%s: Allows for privileged workloads", [core.kind, core.name]))
 }
-
 ```
 _source: [../../examples/psp-deny-privileged](../../examples/psp-deny-privileged)_
 
@@ -555,7 +504,6 @@ _source: [../../examples/psp-deny-privileged](../../examples/psp-deny-privileged
 **Severity:** warn
 
 **Resources:** apps/DaemonSet apps/Deployment
-
 
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
@@ -575,7 +523,6 @@ warn[msg] {
     
     msg := core.format(sprintf("API extensions/v1beta1 for %s has been deprecated, use apps/v1 instead.", [core.kind]))
 }
-
 ```
 _source: [../../examples/any-warn-deprecated-api-versions](../../examples/any-warn-deprecated-api-versions)_
 
@@ -584,7 +531,6 @@ _source: [../../examples/any-warn-deprecated-api-versions](../../examples/any-wa
 **Severity:** warn
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
@@ -612,7 +558,6 @@ no_read_only_filesystem(container) {
 no_read_only_filesystem(container) {
     core.missing_field(container.securityContext, "readOnlyRootFilesystem")
 }
-
 ```
 _source: [../../examples/container-warn-no-ro-fs](../../examples/container-warn-no-ro-fs)_
 
@@ -621,7 +566,6 @@ _source: [../../examples/container-warn-no-ro-fs](../../examples/container-warn-
 **Severity:** warn
 
 **Resources:** policy/PodSecurityPolicy
-
 
 Allowping pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
@@ -648,6 +592,5 @@ no_read_only_filesystem(psp) {
 no_read_only_filesystem(psp) {
     not psp.spec.readOnlyRootFilesystem
 }
-
 ```
 _source: [../../examples/psp-warn-no-ro-fs](../../examples/psp-warn-no-ro-fs)_

--- a/test/doc/expected.md
+++ b/test/doc/expected.md
@@ -35,6 +35,7 @@
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
+
 ### Rego
 
 ```rego
@@ -51,6 +52,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
 }
 ```
+
 _source: [../../examples/container-deny-added-caps](../../examples/container-deny-added-caps)_
 
 ## Containers must not allow for privilege escalation
@@ -61,6 +63,7 @@ _source: [../../examples/container-deny-added-caps](../../examples/container-den
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -84,6 +87,7 @@ allows_escalation(c) {
     core.missing_field(c.securityContext, "allowPrivilegeEscalation")
 }
 ```
+
 _source: [../../examples/container-deny-escalation](../../examples/container-deny-escalation)_
 
 ## Images must not use the latest tag
@@ -94,6 +98,7 @@ _source: [../../examples/container-deny-escalation](../../examples/container-den
 
 Using the latest tag on images can cause unexpected problems in production. By specifing a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
+
 ### Rego
 
 ```rego
@@ -117,6 +122,7 @@ has_latest_tag(c) {
     contains(c.image, ":") == false
 }
 ```
+
 _source: [../../examples/container-deny-latest-tag](../../examples/container-deny-latest-tag)_
 
 ## Containers must not run as privileged
@@ -128,6 +134,7 @@ _source: [../../examples/container-deny-latest-tag](../../examples/container-den
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
 to obtain the same effect are not allowed.
+
 ### Rego
 
 ```rego
@@ -153,6 +160,7 @@ is_privileged(container) {
   security.added_capability(container, "CAP_SYS_ADMIN")
 }
 ```
+
 _source: [../../examples/container-deny-privileged](../../examples/container-deny-privileged)_
 
 ## Containers must define resource constraints
@@ -163,6 +171,7 @@ _source: [../../examples/container-deny-privileged](../../examples/container-den
 
 Resource constraints on containers ensure that a given workload does not take up more resources than it required
 and potentially starve other applications that need to run.
+
 ### Rego
 
 ```rego
@@ -185,6 +194,7 @@ container_resources_provided(container) {
     container.resources.limits.memory
 }
 ```
+
 _source: [../../examples/container-deny-without-resource-constraints](../../examples/container-deny-without-resource-constraints)_
 
 ## Pods must not have access to the host aliases
@@ -195,6 +205,7 @@ _source: [../../examples/container-deny-without-resource-constraints](../../exam
 
 Pods that can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
+
 ### Rego
 
 ```rego
@@ -210,6 +221,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for managing host aliases", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [../../examples/pod-deny-host-alias](../../examples/pod-deny-host-alias)_
 
 ## Pods must not run with access to the host IPC
@@ -220,6 +232,7 @@ _source: [../../examples/pod-deny-host-alias](../../examples/pod-deny-host-alias
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
+
 ### Rego
 
 ```rego
@@ -235,6 +248,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [../../examples/pod-deny-host-ipc](../../examples/pod-deny-host-ipc)_
 
 ## Pods must not run with access to the host networking
@@ -245,6 +259,7 @@ _source: [../../examples/pod-deny-host-ipc](../../examples/pod-deny-host-ipc)_
 
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
+
 ### Rego
 
 ```rego
@@ -260,6 +275,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host network", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [../../examples/pod-deny-host-network](../../examples/pod-deny-host-network)_
 
 ## Pods must not run with access to the host PID namespace
@@ -271,6 +287,7 @@ _source: [../../examples/pod-deny-host-network](../../examples/pod-deny-host-net
 Pods that can acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
+
 ### Rego
 
 ```rego
@@ -286,6 +303,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [../../examples/pod-deny-host-pid](../../examples/pod-deny-host-pid)_
 
 ## Pods must run as non-root
@@ -296,6 +314,7 @@ _source: [../../examples/pod-deny-host-pid](../../examples/pod-deny-host-pid)_
 
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -311,6 +330,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s/%s: Pod allows running as root", [core.kind, core.name, pod.metadata.name]))
 }
 ```
+
 _source: [../../examples/pod-deny-without-runasnonroot](../../examples/pod-deny-without-runasnonroot)_
 
 ## PodSecurityPolicies must require all capabilities are dropped
@@ -322,6 +342,7 @@ _source: [../../examples/pod-deny-without-runasnonroot](../../examples/pod-deny-
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
+
 ### Rego
 
 ```rego
@@ -338,6 +359,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]))
 }
 ```
+
 _source: [../../examples/psp-deny-added-caps](../../examples/psp-deny-added-caps)_
 
 ## PodSecurityPolicies must not allow privileged escalation
@@ -348,6 +370,7 @@ _source: [../../examples/psp-deny-added-caps](../../examples/psp-deny-added-caps
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -371,6 +394,7 @@ allows_escalation(p) {
     core.missing_field(p.spec, "allowPrivilegeEscalation")
 }
 ```
+
 _source: [../../examples/psp-deny-escalation](../../examples/psp-deny-escalation)_
 
 ## PodSecurityPolicies must not allow access to the host aliases
@@ -381,6 +405,7 @@ _source: [../../examples/psp-deny-escalation](../../examples/psp-deny-escalation
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
+
 ### Rego
 
 ```rego
@@ -396,6 +421,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for managing host aliases", [core.kind, core.name]))
 }
 ```
+
 _source: [../../examples/psp-deny-host-alias](../../examples/psp-deny-host-alias)_
 
 ## PodSecurityPolicies must not allow access to the host IPC
@@ -406,6 +432,7 @@ _source: [../../examples/psp-deny-host-alias](../../examples/psp-deny-host-alias
 
 Allowing pods to to access the host IPC can read memory of
 the other containers, breaking that security boundary.
+
 ### Rego
 
 ```rego
@@ -421,6 +448,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]))
 }
 ```
+
 _source: [../../examples/psp-deny-host-ipc](../../examples/psp-deny-host-ipc)_
 
 ## PodSecurityPolicies must not allow access to the host network
@@ -432,6 +460,7 @@ _source: [../../examples/psp-deny-host-ipc](../../examples/psp-deny-host-ipc)_
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
+
 ### Rego
 
 ```rego
@@ -447,6 +476,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for accessing the host network", [core.kind, core.name]))
 }
 ```
+
 _source: [../../examples/psp-deny-host-network](../../examples/psp-deny-host-network)_
 
 ## PodSecurityPolicies must not allow access to the host PID namespace
@@ -458,6 +488,7 @@ _source: [../../examples/psp-deny-host-network](../../examples/psp-deny-host-net
 Allowing pods to acess the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
+
 ### Rego
 
 ```rego
@@ -472,6 +503,7 @@ violation[msg] {
     msg = core.format(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]))
 }
 ```
+
 _source: [../../examples/psp-deny-host-pid](../../examples/psp-deny-host-pid)_
 
 ## PodSecurityPolicies must require containers to not run as privileged
@@ -482,6 +514,7 @@ _source: [../../examples/psp-deny-host-pid](../../examples/psp-deny-host-pid)_
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
+
 ### Rego
 
 ```rego
@@ -497,6 +530,7 @@ violation[msg] {
     msg := core.format(sprintf("%s/%s: Allows for privileged workloads", [core.kind, core.name]))
 }
 ```
+
 _source: [../../examples/psp-deny-privileged](../../examples/psp-deny-privileged)_
 
 ## Deprecated Deployment and DaemonSet API


### PR DESCRIPTION
This just makes the rego that we pull back from source more predictable when it comes to writing documentation.