### PR TITLE
Update host alias policy to array

### DIFF
--- a/examples/pod-deny-host-alias/src.rego
+++ b/examples/pod-deny-host-alias/src.rego
@@ -10,7 +10,11 @@ import data.lib.core
 import data.lib.pods
 
 violation[msg] {
-    pods.pod.spec.hostAliases
+    pod_host_alias
 
-    msg := core.format(sprintf("%s/%s: Pod allows for managing host aliases", [core.kind, core.name]))
+    msg := core.format(sprintf("%s/%s: Pod has hostAliases defined", [core.kind, core.name]))
+}
+
+pod_host_alias {
+    pods.pod.spec.hostAliases
 }

--- a/examples/pod-deny-host-alias/src_test.rego
+++ b/examples/pod-deny-host-alias/src_test.rego
@@ -1,31 +1,23 @@
 package pod_deny_host_alias
 
-test_pos {
+test_input_with_alias_missing {
     input := {
         "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
-        "spec": {
-            "hostAliases": false,
-        }
+        "spec": {}
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not pod_host_alias with input as input
 }
 
-test_neg {
+test_input_with_alias {
     input := {
         "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
         "spec": {
-            "hostAliases": true,
+            "hostAliases": [
+                {"ip": "127.0.0.1", "hostnames": ["foo.local"]}
+            ]
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    pod_host_alias with input as input
 }

--- a/examples/pod-deny-host-alias/template.yaml
+++ b/examples/pod-deny-host-alias/template.yaml
@@ -87,9 +87,13 @@ spec:
       import data.lib.pods
 
       violation[msg] {
-          pods.pod.spec.hostAliases
+          pod_host_alias
 
-          msg := core.format(sprintf("%s/%s: Pod allows for managing host aliases", [core.kind, core.name]))
+          msg := core.format(sprintf("%s/%s: Pod has hostAliases defined", [core.kind, core.name]))
+      }
+
+      pod_host_alias {
+          pods.pod.spec.hostAliases
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -215,9 +215,13 @@ import data.lib.core
 import data.lib.pods
 
 violation[msg] {
-    pods.pod.spec.hostAliases
+    pod_host_alias
 
-    msg := core.format(sprintf("%s/%s: Pod allows for managing host aliases", [core.kind, core.name]))
+    msg := core.format(sprintf("%s/%s: Pod has hostAliases defined", [core.kind, core.name]))
+}
+
+pod_host_alias {
+    pods.pod.spec.hostAliases
 }
 ```
 

--- a/test/doc/expected.md
+++ b/test/doc/expected.md
@@ -215,9 +215,13 @@ import data.lib.core
 import data.lib.pods
 
 violation[msg] {
-    pods.pod.spec.hostAliases
+    pod_host_alias
 
-    msg := core.format(sprintf("%s/%s: Pod allows for managing host aliases", [core.kind, core.name]))
+    msg := core.format(sprintf("%s/%s: Pod has hostAliases defined", [core.kind, core.name]))
+}
+
+pod_host_alias {
+    pods.pod.spec.hostAliases
 }
 ```
 


### PR DESCRIPTION
Noticed that the `hostAliases` check is currently set to `true` / `false`, but its data type is an array. While not a bug from a functionality perspective, using an array is more true to the expected type.