### PR TITLE
Standardize policy testing to not count violations or warns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ policy:
 .PHONY: update-static
 update-static: build
 	./build/konstraint create examples
-	./build/konstraint create examples --output test/create
+	./build/konstraint create test/create --output test/create
 	./build/konstraint doc examples --output examples/policies.md
 	./build/konstraint doc examples --output test/doc/expected.md
 

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -17,7 +17,7 @@
 }
 
 @test "[CREATE] Creating constraints using --output matches expected output" {
-  run ./build/konstraint create examples/container-deny-latest-tag --output test/create
+  run ./build/konstraint create test/create --output test/create
   git diff --quiet -- test/create/constraint_Create.yaml
   git diff --quiet -- test/create/template_Create.yaml
 }

--- a/examples/container-deny-added-caps/src.rego
+++ b/examples/container-deny-added-caps/src.rego
@@ -13,7 +13,11 @@ import data.lib.security
 
 violation[msg] {
     pods.containers[container]
-    not security.dropped_capability(container, "all")
+    not container_dropped_all_capabilities(container)
 
     msg := core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
+}
+
+container_dropped_all_capabilities(container) {
+    security.dropped_capability(container, "all")
 }

--- a/examples/container-deny-added-caps/src_test.rego
+++ b/examples/container-deny-added-caps/src_test.rego
@@ -1,43 +1,22 @@
 package container_deny_added_caps
 
-test_pos {
+test_dropped_all {
     input := {
-        "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
-        "spec": {
-            "containers": [{
-                "name": "test-container",
-                "securityContext": {
-                    "capabilities": {
-                        "drop": ["alL"]
-                    }
-                }
-            }]
+        "securityContext": {
+            "capabilities": {"drop": ["alL"]}
         }
     }
-    violations := violation with input as input
-    count(violations) == 0
+
+    
+    container_dropped_all_capabilities(input)
 }
 
-test_neg {
+test_dropped_none {
     input := {
-        "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
-        "spec": {
-            "containers": [{
-                "name": "test-container",
-                "securityContext": {
-                    "capabilities": {
-                        "drop": ["none"]
-                    }
-                }
-            }]
+        "securityContext": {
+            "capabilities": {"drop": ["none"]}
         }
     }
-    violations := violation with input as input
-    count(violations) == 1
+    
+    not container_dropped_all_capabilities(input)
 }

--- a/examples/container-deny-added-caps/template.yaml
+++ b/examples/container-deny-added-caps/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]
@@ -111,9 +113,13 @@ spec:
 
       violation[msg] {
           pods.containers[container]
-          not security.dropped_capability(container, "all")
+          not container_dropped_all_capabilities(container)
 
           msg := core.format(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]))
+      }
+
+      container_dropped_all_capabilities(container) {
+          security.dropped_capability(container, "all")
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/container-deny-escalation/src.rego
+++ b/examples/container-deny-escalation/src.rego
@@ -10,16 +10,16 @@ import data.lib.core
 import data.lib.pods
 
 violation[msg] {
-    container_allows_escalation
+    pods.containers[container]
+    container_allows_escalation(container)
 
     msg := core.format(sprintf("%s/%s: Allows privilege escalation", [core.kind, core.name]))
 }
 
-
-container_allows_escalation {
-    pods.containers[_].securityContext.allowPrivilegeEscalation == true
+container_allows_escalation(c) {
+    c.securityContext.allowPrivilegeEscalation == true
 }
 
-container_allows_escalation {
-    core.missing_field(pods.containers[_].securityContext, "allowPrivilegeEscalation")
+container_allows_escalation(c) {
+    core.missing_field(c.securityContext, "allowPrivilegeEscalation")
 }

--- a/examples/container-deny-escalation/src_test.rego
+++ b/examples/container-deny-escalation/src_test.rego
@@ -1,41 +1,13 @@
 package container_deny_escalation
 
-test_pos {
-    input := {
-        "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
-        "spec": {
-            "containers": [{
-                "name": "test-container",
-                "securityContext": {
-                    "allowPrivilegeEscalation": false
-                }
-            }]
-        }
-    }
+test_allowescalation_false {
+    input := {"securityContext": {"allowPrivilegeEscalation": false}}
 
-    violations := violation with input as input
-    count(violations) == 0
+    not container_allows_escalation(input)
 }
 
-test_neg {
-    input := {
-        "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
-        "spec": {
-            "containers": [{
-                "name": "test-container",
-                "securityContext": {
-                    "allowPrivilegeEscalation": true
-                }
-            }]
-        }
-    }
+test_allowescalation_true {
+    input := {"securityContext": {"allowPrivilegeEscalation": true}}
     
-    violations := violation with input as input
-    count(violations) == 1
+    container_allows_escalation(input)
 }

--- a/examples/container-deny-escalation/template.yaml
+++ b/examples/container-deny-escalation/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]
@@ -87,18 +89,18 @@ spec:
       import data.lib.pods
 
       violation[msg] {
-          container_allows_escalation
+          pods.containers[container]
+          container_allows_escalation(container)
 
           msg := core.format(sprintf("%s/%s: Allows privilege escalation", [core.kind, core.name]))
       }
 
-
-      container_allows_escalation {
-          pods.containers[_].securityContext.allowPrivilegeEscalation == true
+      container_allows_escalation(c) {
+          c.securityContext.allowPrivilegeEscalation == true
       }
 
-      container_allows_escalation {
-          core.missing_field(pods.containers[_].securityContext, "allowPrivilegeEscalation")
+      container_allows_escalation(c) {
+          core.missing_field(c.securityContext, "allowPrivilegeEscalation")
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/container-deny-latest-tag/src_test.rego
+++ b/examples/container-deny-latest-tag/src_test.rego
@@ -1,40 +1,19 @@
 package container_deny_latest_tag
 
 test_input_as_image_without_latest_tag {
-    input := {
-        "kind": "Pod",
-        "metadata": {"name": "test"},
-        "spec": {
-        "containers": [{"name": "test", "image": "image:1.0.0"}]
-        }
-    }
+    input := {"name": "test", "image": "image:1.0.0"}
 
-    violations := violation with input as input
-    count(violations) == 0
+    not has_latest_tag(input)
 }
 
 test_input_as_image_with_latest_tag {
-    input := {
-        "kind": "Pod",
-        "metadata": {"name": "test"},
-        "spec": {
-        "containers": [{"name": "test", "image": "image:latest"}]
-        }
-    }
+    input := {"name": "test", "image": "image:latest"}
 
-    violations := violation with input as input
-    count(violations) == 1
+    has_latest_tag(input)
 }
 
 test_input_as_image_with_no_tag {
-    input := {
-        "kind": "Pod",
-        "metadata": {"name": "test"},
-        "spec": {
-        "containers": [{"name": "test", "image": "image"}]
-        }
-    }
+    input := {"name": "test", "image": "image"}
 
-    violations := violation with input as input
-    count(violations) == 1
+    has_latest_tag(input)
 }

--- a/examples/container-deny-latest-tag/template.yaml
+++ b/examples/container-deny-latest-tag/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]

--- a/examples/container-deny-privileged/src.rego
+++ b/examples/container-deny-privileged/src.rego
@@ -13,16 +13,16 @@ import data.lib.security
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
 violation[msg] {
-  pods.containers[container]
-  is_privileged(container)
+    pods.containers[container]
+    container_is_privileged(container)
 
-  msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))
+    msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))
 }
 
-is_privileged(container) {
-  container.securityContext.privileged
+container_is_privileged(container) {
+    container.securityContext.privileged
 }
 
-is_privileged(container) {
-  security.added_capability(container, "CAP_SYS_ADMIN")
+container_is_privileged(container) {
+    security.added_capability(container, "CAP_SYS_ADMIN")
 }

--- a/examples/container-deny-privileged/src_test.rego
+++ b/examples/container-deny-privileged/src_test.rego
@@ -1,67 +1,23 @@
 package container_deny_privileged
 
-test_privileged {
-  input := {
-    "kind": "Pod",
-    "metadata": {"name": "test"},
-    "spec": {
-      "containers": [{
-        "name": "test",
-        "securityContext": {
-          "privileged": true
-        }
-      }]
-    }
-  }
+test_privileged_true {
+    input := {"securityContext": {"privileged": true}}
 
-  violations := violation with input as input
-  count(violations) == 1
+    container_is_privileged(input)
 }
 
-test_not_privileged {
-  input := {
-    "kind": "Pod",
-    "metadata": {"name": "test"},
-    "spec": {
-      "containers": [{
-        "name": "test",
-        "securityContext": {
-          "privileged": false
-        }
-      }]
-    }
-  }
+test_privileged_false {
+    input := {"securityContext": {"privileged": false}}
 
-  violations := violation with input as input
-  count(violations) == 0
+    not container_is_privileged(input)
 }
 
 test_added_capability {
-  input := {
-    "kind": "Pod",
-    "metadata": {"name": "test"},
-    "spec": {
-      "containers": [{
-        "name": "test",
+    input := {
         "securityContext": {
-          "capabilities": {
-            "add": ["CAP_SYS_ADMIN"]
-          }
+            "capabilities": {"add": ["CAP_SYS_ADMIN"]}
         }
-      }]
     }
-  }
 
-  violations := violation with input as input
-  count(violations) == 1
-}
-
-test_null {
-  input := {
-    "kind": "Pod",
-    "metadata": {"name": "test"},
-  }
-
-  violations := violation with input as input
-  count(violations) == 0
+    container_is_privileged(input)
 }

--- a/examples/container-deny-privileged/template.yaml
+++ b/examples/container-deny-privileged/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]
@@ -111,18 +113,18 @@ spec:
 
 
       violation[msg] {
-        pods.containers[container]
-        is_privileged(container)
+          pods.containers[container]
+          container_is_privileged(container)
 
-        msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))
+          msg = core.format(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]))
       }
 
-      is_privileged(container) {
-        container.securityContext.privileged
+      container_is_privileged(container) {
+          container.securityContext.privileged
       }
 
-      is_privileged(container) {
-        security.added_capability(container, "CAP_SYS_ADMIN")
+      container_is_privileged(container) {
+          security.added_capability(container, "CAP_SYS_ADMIN")
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/container-deny-without-resource-constraints/src_test.rego
+++ b/examples/container-deny-without-resource-constraints/src_test.rego
@@ -2,20 +2,24 @@ package container_deny_without_resource_constraints
 
 test_input_as_container_missing_resources {
     container := {}
+
     not container_resources_provided(container)
 }
 
 test_input_as_container_with_missing_memory_requests {
     container := {"resources": {"requests": {"cpu": "1"}}}
+
     not container_resources_provided(container)
 }
 
 test_input_as_container_with_missing_limits_constraint {
     container := {"resources": {"requests": {"cpu": "1", "memory": "1"}}}
+
     not container_resources_provided(container)
 }
 
 test_input_as_container_with_all_constraints {
     container := {"resources": {"requests": {"cpu": "1", "memory": "1"}, "limits": {"cpu": "1", "memory": "1"}}}
+    
     container_resources_provided(container)
 }

--- a/examples/container-deny-without-resource-constraints/template.yaml
+++ b/examples/container-deny-without-resource-constraints/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]

--- a/examples/container-warn-no-ro-fs/src_test.rego
+++ b/examples/container-warn-no-ro-fs/src_test.rego
@@ -1,39 +1,13 @@
 package container_warn_no_ro_fs
 
-test_pos {
-    input := {
-        "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
-        "spec": {
-            "containers": [{
-                "name": "test-container",
-                "securityContext": {
-                    "readOnlyRootFilesystem": true
-                }
-            }]
-        }
-    }
-    warns := warn with input as input
-    count(warns) == 0
+test_rofs_true {
+    input := {"securityContext": {"readOnlyRootFilesystem": true}}
+    
+    not no_read_only_filesystem(input)
 }
 
-test_neg {
-    input := {
-        "kind": "Pod",
-        "metadata": {
-            "name": "test-pod"
-        },
-        "spec": {
-            "containers": [{
-                "name": "test-container",
-                "securityContext": {
-                    "readOnlyRootFilesystem": false
-                }
-            }]
-        }
-    }
-    warns := warn with input as input
-    count(warns) == 1
+test_rofs_false {
+    input := {"securityContext": {"readOnlyRootFilesystem": false}}
+    
+    no_read_only_filesystem(input)
 }

--- a/examples/pod-deny-host-alias/template.yaml
+++ b/examples/pod-deny-host-alias/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]

--- a/examples/pod-deny-host-ipc/src.rego
+++ b/examples/pod-deny-host-ipc/src.rego
@@ -10,7 +10,11 @@ import data.lib.core
 import data.lib.pods
 
 violation[msg] {
-    pods.pod.spec.hostIPC
+    pod_has_hostipc
 
     msg := core.format(sprintf("%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name]))
+}
+
+pod_has_hostipc {
+    pods.pod.spec.hostIPC
 }

--- a/examples/pod-deny-host-ipc/src_test.rego
+++ b/examples/pod-deny-host-ipc/src_test.rego
@@ -1,6 +1,6 @@
 package pod_deny_host_ipc
 
-test_pos {
+test_hostipc_false {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not pod_has_hostipc with input as input
 }
 
-test_neg {
+test_hostipc_true {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -26,6 +25,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    pod_has_hostipc with input as input
 }

--- a/examples/pod-deny-host-ipc/template.yaml
+++ b/examples/pod-deny-host-ipc/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]
@@ -87,9 +89,13 @@ spec:
       import data.lib.pods
 
       violation[msg] {
-          pods.pod.spec.hostIPC
+          pod_has_hostipc
 
           msg := core.format(sprintf("%s/%s: Pod allows for accessing the host IPC", [core.kind, core.name]))
+      }
+
+      pod_has_hostipc {
+          pods.pod.spec.hostIPC
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/pod-deny-host-network/src.rego
+++ b/examples/pod-deny-host-network/src.rego
@@ -10,7 +10,11 @@ import data.lib.core
 import data.lib.pods
 
 violation[msg] {
-    pods.pod.spec.hostNetwork
+    pod_has_hostnetwork
 
     msg := core.format(sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]))
+}
+
+pod_has_hostnetwork {
+    pods.pod.spec.hostNetwork
 }

--- a/examples/pod-deny-host-network/src_test.rego
+++ b/examples/pod-deny-host-network/src_test.rego
@@ -1,6 +1,6 @@
 package pod_deny_host_network
 
-test_pos {
+test_hostnetwork_false {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not pod_has_hostnetwork with input as input
 }
 
-test_neg {
+test_hostnetwork_true {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -26,6 +25,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    pod_has_hostnetwork with input as input
 }

--- a/examples/pod-deny-host-network/template.yaml
+++ b/examples/pod-deny-host-network/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]
@@ -87,9 +89,13 @@ spec:
       import data.lib.pods
 
       violation[msg] {
-          pods.pod.spec.hostNetwork
+          pod_has_hostnetwork
 
           msg := core.format(sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]))
+      }
+
+      pod_has_hostnetwork {
+          pods.pod.spec.hostNetwork
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/pod-deny-host-pid/src.rego
+++ b/examples/pod-deny-host-pid/src.rego
@@ -11,7 +11,11 @@ import data.lib.core
 import data.lib.pods
 
 violation[msg] {
-    pods.pod.spec.hostPID
+    pod_has_hostpid
 
     msg := core.format(sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]))
+}
+
+pod_has_hostpid {
+    pods.pod.spec.hostPID
 }

--- a/examples/pod-deny-host-pid/src_test.rego
+++ b/examples/pod-deny-host-pid/src_test.rego
@@ -1,6 +1,6 @@
 package pod_deny_host_pid
 
-test_pos {
+test_hostpid_false {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not pod_has_hostpid with input as input
 }
 
-test_neg {
+test_hostpid_true {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -26,6 +25,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    pod_has_hostpid with input as input
 }

--- a/examples/pod-deny-host-pid/template.yaml
+++ b/examples/pod-deny-host-pid/template.yaml
@@ -58,6 +58,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]
@@ -87,9 +89,13 @@ spec:
       import data.lib.pods
 
       violation[msg] {
-          pods.pod.spec.hostPID
+          pod_has_hostpid
 
           msg := core.format(sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]))
+      }
+
+      pod_has_hostpid {
+          pods.pod.spec.hostPID
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/pod-deny-without-runasnonroot/src.rego
+++ b/examples/pod-deny-without-runasnonroot/src.rego
@@ -11,7 +11,11 @@ import data.lib.core
 
 violation[msg] {
     pods.pod
-    not pods.pod.spec.securityContext.runAsNonRoot
+    not pod_runasnonroot
 
     msg := core.format(sprintf("%s/%s: Pod allows running as root", [core.kind, core.name]))
+}
+
+pod_runasnonroot {
+    pods.pod.spec.securityContext.runAsNonRoot
 }

--- a/examples/pod-deny-without-runasnonroot/src_test.rego
+++ b/examples/pod-deny-without-runasnonroot/src_test.rego
@@ -1,6 +1,6 @@
 package pod_deny_without_runasnonroot
 
-test_pos {
+test_runasnonroot_true {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -13,26 +13,21 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    pod_runasnonroot with input as input
 }
 
-test_null {
+test_runasnonroot_null {
     input := {
         "kind": "Pod",
         "metadata": {
             "name": "test-pod"
-        },
-        "spec": {
-            "securityContext": {}
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    not pod_runasnonroot with input as input
 }
 
-test_neg {
+test_runasnonroot_false {
     input := {
         "kind": "Pod",
         "metadata": {
@@ -45,6 +40,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    not pod_runasnonroot with input as input
 }

--- a/examples/pod-deny-without-runasnonroot/template.yaml
+++ b/examples/pod-deny-without-runasnonroot/template.yaml
@@ -15,6 +15,8 @@ spec:
 
       import data.lib.core
 
+      default pod = false
+
       pod = core.resource.spec.template {
           pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
           lower(core.kind) == pod_templates[_]
@@ -88,9 +90,13 @@ spec:
 
       violation[msg] {
           pods.pod
-          not pods.pod.spec.securityContext.runAsNonRoot
+          not pod_runasnonroot
 
           msg := core.format(sprintf("%s/%s: Pod allows running as root", [core.kind, core.name]))
+      }
+
+      pod_runasnonroot {
+          pods.pod.spec.securityContext.runAsNonRoot
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/psp-deny-added-caps/src.rego
+++ b/examples/psp-deny-added-caps/src.rego
@@ -12,8 +12,12 @@ import data.lib.psps
 import data.lib.security
 
 violation[msg] {
-    psps.psps[psp]
-    not security.dropped_capability(psp, "all")
+    not psp_dropped_all_capabilities
 
     msg := core.format(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]))
+}
+
+psp_dropped_all_capabilities {
+    psps.psps[psp]
+    security.dropped_capability(psp, "all")
 }

--- a/examples/psp-deny-added-caps/src_test.rego
+++ b/examples/psp-deny-added-caps/src_test.rego
@@ -1,6 +1,6 @@
 package psp_deny_added_caps
 
-test_pos {
+test_dropped_all {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -13,8 +13,7 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    psp_dropped_all_capabilities with input as input
 }
 
 test_case_insensitivty {
@@ -30,8 +29,7 @@ test_case_insensitivty {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    psp_dropped_all_capabilities with input as input
 }
 
 test_null {
@@ -45,11 +43,10 @@ test_null {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    not psp_dropped_all_capabilities with input as input
 }
 
-test_neg {
+test_dropped_none {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -62,6 +59,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    not psp_dropped_all_capabilities with input as input
 }

--- a/examples/psp-deny-added-caps/template.yaml
+++ b/examples/psp-deny-added-caps/template.yaml
@@ -106,10 +106,14 @@ spec:
       import data.lib.security
 
       violation[msg] {
-          psps.psps[psp]
-          not security.dropped_capability(psp, "all")
+          not psp_dropped_all_capabilities
 
           msg := core.format(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]))
+      }
+
+      psp_dropped_all_capabilities {
+          psps.psps[psp]
+          security.dropped_capability(psp, "all")
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/psp-deny-escalation/src_test.rego
+++ b/examples/psp-deny-escalation/src_test.rego
@@ -1,6 +1,6 @@
 package psp_deny_escalation
 
-test_pos {
+test_allowescalation_false {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -11,8 +11,7 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not allows_escalation(input)
 }
 
 test_null {
@@ -26,11 +25,10 @@ test_null {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    allows_escalation(input)
 }
 
-test_neg {
+test_allowescalation_true {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -41,6 +39,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    allows_escalation(input)
 }

--- a/examples/psp-deny-host-alias/src.rego
+++ b/examples/psp-deny-host-alias/src.rego
@@ -10,8 +10,11 @@ import data.lib.core
 import data.lib.psps
 
 violation[msg] {
-    psps.psps[psp]
-    psp.spec.hostAliases
+    psp_allows_hostaliases
 
     msg := core.format(sprintf("%s/%s: Allows for managing host aliases", [core.kind, core.name]))
+}
+
+psp_allows_hostaliases {
+    psps.psps[_].spec.hostAliases
 }

--- a/examples/psp-deny-host-alias/src_test.rego
+++ b/examples/psp-deny-host-alias/src_test.rego
@@ -1,6 +1,6 @@
 package psp_deny_host_alias
 
-test_pos {
+test_hostaliases_false {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not psp_allows_hostaliases with input as input
 }
 
-test_neg {
+test_hostaliases_true {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -26,6 +25,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    psp_allows_hostaliases with input as input
 }

--- a/examples/psp-deny-host-alias/template.yaml
+++ b/examples/psp-deny-host-alias/template.yaml
@@ -83,10 +83,13 @@ spec:
       import data.lib.psps
 
       violation[msg] {
-          psps.psps[psp]
-          psp.spec.hostAliases
+          psp_allows_hostaliases
 
           msg := core.format(sprintf("%s/%s: Allows for managing host aliases", [core.kind, core.name]))
+      }
+
+      psp_allows_hostaliases {
+          psps.psps[_].spec.hostAliases
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/psp-deny-host-ipc/src.rego
+++ b/examples/psp-deny-host-ipc/src.rego
@@ -10,8 +10,11 @@ import data.lib.core
 import data.lib.psps
 
 violation[msg] {
-    psps.psps[psp]
-    psp.spec.hostIPC
+    psp_allows_hostipc
 
     msg := core.format(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]))
+}
+
+psp_allows_hostipc {
+    psps.psps[_].spec.hostIPC
 }

--- a/examples/psp-deny-host-ipc/src_test.rego
+++ b/examples/psp-deny-host-ipc/src_test.rego
@@ -1,6 +1,6 @@
 package psp_deny_host_ipc
 
-test_pos {
+test_hostipc_false {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not psp_allows_hostipc with input as input
 }
 
-test_neg {
+test_hostipc_true {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -26,6 +25,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    psp_allows_hostipc with input as input
 }

--- a/examples/psp-deny-host-ipc/template.yaml
+++ b/examples/psp-deny-host-ipc/template.yaml
@@ -83,10 +83,13 @@ spec:
       import data.lib.psps
 
       violation[msg] {
-          psps.psps[psp]
-          psp.spec.hostIPC
+          psp_allows_hostipc
 
           msg := core.format(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]))
+      }
+
+      psp_allows_hostipc {
+          psps.psps[_].spec.hostIPC
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/psp-deny-host-network/src.rego
+++ b/examples/psp-deny-host-network/src.rego
@@ -11,8 +11,11 @@ import data.lib.core
 import data.lib.psps
 
 violation[msg] {
-    psps.psps[psp]
-    psp.spec.hostNetwork
+    psp_allows_hostnetwork
 
     msg := core.format(sprintf("%s/%s: Allows for accessing the host network", [core.kind, core.name]))
+}
+
+psp_allows_hostnetwork {
+    psps.psps[_].spec.hostNetwork
 }

--- a/examples/psp-deny-host-network/src_test.rego
+++ b/examples/psp-deny-host-network/src_test.rego
@@ -1,6 +1,6 @@
 package psp_deny_host_network
 
-test_pos {
+test_hostnetwork_false {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not psp_allows_hostnetwork with input as input
 }
 
-test_neg {
+test_hostnetwork_true {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -26,6 +25,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    psp_allows_hostnetwork with input as input
 }

--- a/examples/psp-deny-host-network/template.yaml
+++ b/examples/psp-deny-host-network/template.yaml
@@ -83,10 +83,13 @@ spec:
       import data.lib.psps
 
       violation[msg] {
-          psps.psps[psp]
-          psp.spec.hostNetwork
+          psp_allows_hostnetwork
 
           msg := core.format(sprintf("%s/%s: Allows for accessing the host network", [core.kind, core.name]))
+      }
+
+      psp_allows_hostnetwork {
+          psps.psps[_].spec.hostNetwork
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/psp-deny-host-pid/src.rego
+++ b/examples/psp-deny-host-pid/src.rego
@@ -11,7 +11,11 @@ import data.lib.core
 import data.lib.psps
 
 violation[msg] {
-    psps.psps[psp]
-    psp.spec.hostPID
+    psp_allows_hostpid
+    
     msg = core.format(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]))
+}
+
+psp_allows_hostpid {
+    psps.psps[_].spec.hostPID
 }

--- a/examples/psp-deny-host-pid/src_test.rego
+++ b/examples/psp-deny-host-pid/src_test.rego
@@ -1,6 +1,6 @@
 package psp_deny_host_pid
 
-test_pos {
+test_hostpid_false {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not psp_allows_hostpid with input as input
 }
 
-test_neg {
+test_hostpid_true {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -26,6 +25,5 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    psp_allows_hostpid with input as input
 }

--- a/examples/psp-deny-host-pid/template.yaml
+++ b/examples/psp-deny-host-pid/template.yaml
@@ -76,16 +76,9 @@ spec:
           not is_exception
           psp = core.resource
       }
-    rego: |
-      package psp_deny_host_pid
-
-      import data.lib.core
-      import data.lib.psps
-
-      violation[msg] {
-          psps.psps[psp]
-          psp.spec.hostPID
-          msg = core.format(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]))
-      }
+    rego: "package psp_deny_host_pid\n\nimport data.lib.core\nimport data.lib.psps\n\nviolation[msg]
+      {\n    psp_allows_hostpid\n    \n    msg = core.format(sprintf(\"%s/%s: Allows
+      for sharing the host PID namespace\", [core.kind, core.name]))\n}\n\npsp_allows_hostpid
+      {\n    psps.psps[_].spec.hostPID\n}\n"
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/psp-deny-privileged/src.rego
+++ b/examples/psp-deny-privileged/src.rego
@@ -10,8 +10,11 @@ import data.lib.core
 import data.lib.psps
 
 violation[msg] {
-    psps.psps[psp]
-    psp.spec.privileged
+    psp_allows_privileged
 
     msg := core.format(sprintf("%s/%s: Allows for privileged workloads", [core.kind, core.name]))
+}
+
+psp_allows_privileged {
+    psps.psps[_].spec.privileged
 }

--- a/examples/psp-deny-privileged/src_test.rego
+++ b/examples/psp-deny-privileged/src_test.rego
@@ -1,6 +1,6 @@
 package psp_deny_privileged
 
-test_pos {
+test_privileged_false {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -11,11 +11,10 @@ test_pos {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 0
+    not psp_allows_privileged with input as input
 }
 
-test_neg {
+test_privileged_true {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -26,7 +25,6 @@ test_neg {
         }
     }
 
-    violations := violation with input as input
-    count(violations) == 1
+    psp_allows_privileged with input as input
 }
 

--- a/examples/psp-deny-privileged/template.yaml
+++ b/examples/psp-deny-privileged/template.yaml
@@ -83,10 +83,13 @@ spec:
       import data.lib.psps
 
       violation[msg] {
-          psps.psps[psp]
-          psp.spec.privileged
+          psp_allows_privileged
 
           msg := core.format(sprintf("%s/%s: Allows for privileged workloads", [core.kind, core.name]))
+      }
+
+      psp_allows_privileged {
+          psps.psps[_].spec.privileged
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/psp-warn-no-ro-fs/src_test.rego
+++ b/examples/psp-warn-no-ro-fs/src_test.rego
@@ -1,6 +1,6 @@
 package psp_warn_no_ro_fs
 
-test_happy {
+test_rofs_true {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -10,8 +10,8 @@ test_happy {
             "readOnlyRootFilesystem": true
         }
     }
-    violations := warn with input as input
-    count(violations) == 0
+
+    not no_read_only_filesystem(input)
 }
 
 test_null {
@@ -24,11 +24,11 @@ test_null {
             "a": "b"
         }
     }
-    violations := warn with input as input
-    count(violations) == 1
+
+    no_read_only_filesystem(input)
 }
 
-test_neg {
+test_rofs_false {
     input := {
         "kind": "PodSecurityPolicy",
         "metadata": {
@@ -38,6 +38,6 @@ test_neg {
             "readOnlyRootFilesystem": false
         }
     }
-    violations := warn with input as input
-    count(violations) == 1
+
+    no_read_only_filesystem(input)
 }


### PR DESCRIPTION
This standardized the policy testing to no longer rely on counting the `violation`s. This has an added benefit of significantly reducing the size of the test resource in some cases.

I will generate the updated resources and documentation after review to keep the changes to be reviewed as minimal as possible.