### PR TITLE
Add base RBAC library

### DIFF
--- a/examples/lib/rbac.rego
+++ b/examples/lib/rbac.rego
@@ -8,7 +8,7 @@ rule_has_verb(rule, verb) {
 }
 
 rule_has_resource_type(rule, type) {
-    types := ["resourceall", lower(type)]
+    types := ["*", lower(type)]
     types[_] == lower(rule.resources[_])
 }
 

--- a/examples/lib/rbac.rego
+++ b/examples/lib/rbac.rego
@@ -1,0 +1,21 @@
+package lib.rbac
+
+import data.lib.core
+
+rule_has_verb(rule, verb) {
+    verbs := ["*", lower(verb)]
+    verbs[_] == lower(rule.verbs[_])
+}
+
+rule_has_resource_type(rule, type) {
+    types := ["resourceall", lower(type)]
+    types[_] == lower(rule.resources[_])
+}
+
+rule_has_resource_name(rule, name) {
+    name == rule.resourceNames[_]
+}
+
+rule_has_resource_name(rule, name) {
+    core.missing_field(rule, "resourceNames")
+}

--- a/examples/lib/rbac_test.rego
+++ b/examples/lib/rbac_test.rego
@@ -25,7 +25,7 @@ test_rule_has_resource_type_with_pod {
 }
 
 test_rule_has_resource_type_with_resourceall {
-    input := {"resources": ["ResourceAll"]}
+    input := {"resources": ["*"]}
 
     rule_has_resource_type(input, "pod")
 }

--- a/examples/lib/rbac_test.rego
+++ b/examples/lib/rbac_test.rego
@@ -1,0 +1,55 @@
+package lib.rbac
+
+test_rule_has_verb_with_use {
+    input := {"verbs": ["use"]}
+
+    rule_has_verb(input, "use")
+}
+
+test_rule_has_verb_with_asterisk {
+    input := {"verbs": ["*"]}
+
+    rule_has_verb(input, "use")
+}
+
+test_rule_has_verb_with_list {
+    input := {"verbs": ["list"]}
+
+    not rule_has_verb(input, "use")
+}
+
+test_rule_has_resource_type_with_pod {
+    input := {"resources": ["Pod"]}
+
+    rule_has_resource_type(input, "pod")
+}
+
+test_rule_has_resource_type_with_resourceall {
+    input := {"resources": ["ResourceAll"]}
+
+    rule_has_resource_type(input, "pod")
+}
+
+test_rule_has_resource_type_with_container {
+    input := {"resources": ["Container"]}
+
+    not rule_has_resource_type(input, "pod")
+}
+
+test_rule_has_resource_name_match {
+    input := {"resourceNames": ["test"]}
+
+    rule_has_resource_name(input, "test")
+}
+
+test_rule_has_resource_name_no_match {
+    input := {"resourceNames": ["test"]}
+
+    not rule_has_resource_name(input, "wrong")
+}
+
+test_rule_has_resource_name_null {
+    input := {}
+
+    rule_has_resource_name(input, "wrong")
+}


### PR DESCRIPTION
This adds a few functions for working with Kubernetes RBAC. These can be chained together and used with other resources replicated into Gatekeeper's `data.inventory` cache to make decisions based on the properties of the resources rather than relying solely on resource names. 