### PR TITLE
Do not filter rule names if they do not use core.format()

### DIFF
--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -157,7 +157,7 @@ func getFiles(files []string) ([]File, error) {
 }
 
 func getRuleNamesFromModule(module *ast.Module) ([]string, error) {
-	re, err := regexp.Compile(`^\s*([a-z]+)\s*\[\s*msg`)
+	re, err := regexp.Compile(`^\s*([a-z]+)\s*\[\s*\{?\s*"?msg`)
 	if err != nil {
 		return nil, fmt.Errorf("compile regex: %w", err)
 	}


### PR DESCRIPTION
This fixes a bug where if a rule signature was written as `violation[{"msg": msg}]` if would be skipped during constraint and docs generation. This typically wouldn't happen if users are using the `core.format()` function, but we don't want to force that on everyone. Regex tests: https://regex101.com/r/W0dj5Y/2