### PR TITLE
Add example for denying Roles to use privileged PodSecurityPolicies

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.14.4'
+          go-version: '1.14.x'
 
       - name: checkout source
         uses: actions/checkout@v2
@@ -35,4 +35,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: verify policies
-        run: conftest verify -p examples
+        run: conftest verify -p examples -d examples/test-data

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -19,6 +19,7 @@
 * [PodSecurityPolicies must not allow access to the host network](#podsecuritypolicies-must-not-allow-access-to-the-host-network)
 * [PodSecurityPolicies must not allow access to the host PID namespace](#podsecuritypolicies-must-not-allow-access-to-the-host-pid-namespace)
 * [PodSecurityPolicies must require containers to not run as privileged](#podsecuritypolicies-must-require-containers-to-not-run-as-privileged)
+* [Roles must not allow use of privileged PodSecurityPolicies](#roles-must-not-allow-use-of-privileged-podsecuritypolicies)
 
 ## Warnings
 
@@ -571,6 +572,52 @@ psp_allows_privileged {
 ```
 
 _source: [psp-deny-privileged](psp-deny-privileged)_
+
+## Roles must not allow use of privileged PodSecurityPolicies
+
+**Severity:** Violation
+
+**Resources:** rbac.authorization.k8s.io/Role
+
+Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
+
+### Rego
+
+```rego
+package role_deny_use_privileged_psps
+
+import data.lib.core
+import data.lib.rbac
+import data.lib.security
+
+violation[msg] {
+    role_uses_privileged_psp
+
+    msg := core.format(sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]))
+}
+
+role_uses_privileged_psp {
+    rule := core.resource.rules[_]
+    rbac.rule_has_resource_type(rule, "podsecuritypolicies")
+    rbac.rule_has_verb(rule, "use")
+    rbac.rule_has_resource_name(rule, privileged_psps[_].metadata.name)
+}
+
+privileged_psps[psp] {
+    psp := data.inventory.cluster["policy/v1beta1"].PodSecurityPolicy[_]
+    psp_is_privileged(psp)
+}
+
+psp_is_privileged(psp) {
+    psp.spec.privileged
+}
+
+psp_is_privileged(psp) {
+    security.added_capability(psp, "SYS_ADMIN")
+}
+```
+
+_source: [role-deny-use-privileged-psp](role-deny-use-privileged-psp)_
 
 ## Deprecated Deployment and DaemonSet API
 

--- a/examples/role-deny-use-privileged-psp/constraint.yaml
+++ b/examples/role-deny-use-privileged-psp/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RoleDenyUsePrivilegedPsp
+metadata:
+  name: roledenyuseprivilegedpsp
+spec:
+  match:
+    kinds:
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      kinds:
+      - Role

--- a/examples/role-deny-use-privileged-psp/src.rego
+++ b/examples/role-deny-use-privileged-psp/src.rego
@@ -1,0 +1,36 @@
+# @title Roles must not allow use of privileged PodSecurityPolicies
+# 
+# Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
+#
+# @kinds rbac.authorization.k8s.io/Role
+package role_deny_use_privileged_psps
+
+import data.lib.core
+import data.lib.rbac
+import data.lib.security
+
+violation[msg] {
+    role_uses_privileged_psp
+
+    msg := core.format(sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]))
+}
+
+role_uses_privileged_psp {
+    rule := core.resource.rules[_]
+    rbac.rule_has_resource_type(rule, "podsecuritypolicies")
+    rbac.rule_has_verb(rule, "use")
+    rbac.rule_has_resource_name(rule, privileged_psps[_].metadata.name)
+}
+
+privileged_psps[psp] {
+    psp := data.inventory.cluster["policy/v1beta1"].PodSecurityPolicy[_]
+    psp_is_privileged(psp)
+}
+
+psp_is_privileged(psp) {
+    psp.spec.privileged
+}
+
+psp_is_privileged(psp) {
+    security.added_capability(psp, "SYS_ADMIN")
+}

--- a/examples/role-deny-use-privileged-psp/src_test.rego
+++ b/examples/role-deny-use-privileged-psp/src_test.rego
@@ -1,0 +1,72 @@
+package role_deny_use_privileged_psps
+
+test_role_uses_privileged_psp_match {
+    input := {
+        "rules": [{
+            "resourceNames": ["test"],
+            "resources": ["podsecuritypolicies"],
+            "verbs": ["use"]
+        }]
+    }
+
+    role_uses_privileged_psp with input as input
+}
+
+test_role_uses_privileged_psp_wildcard_verb {
+    input := {
+        "rules": [{
+            "resourceNames": ["test"],
+            "resources": ["podsecuritypolicies"],
+            "verbs": ["*"]
+        }]
+    }
+
+    role_uses_privileged_psp with input as input
+}
+
+test_role_uses_privileged_psp_no_resource_names {
+    input := {
+        "rules": [{
+            "resources": ["podsecuritypolicies"],
+            "verbs": ["use"]
+        }]
+    }
+
+    role_uses_privileged_psp with input as input
+}
+
+test_role_uses_privileged_psp_wrong_name {
+    input := {
+        "rules": [{
+            "resourceNames": ["wrong"],
+            "resources": ["podsecuritypolicies"],
+            "verbs": ["use"]
+        }]
+    }
+
+    not role_uses_privileged_psp with input as input
+}
+
+test_role_uses_privileged_psp_wrong_resource_type {
+    input := {
+        "rules": [{
+            "resourceNames": ["test"],
+            "resources": ["wrong"],
+            "verbs": ["use"]
+        }]
+    }
+
+    not role_uses_privileged_psp with input as input
+}
+
+test_role_uses_privileged_psp_wrong_verb {
+    input := {
+        "rules": [{
+            "resourceNames": ["test"],
+            "resources": ["podsecuritypolicies"],
+            "verbs": ["wrong"]
+        }]
+    }
+
+    not role_uses_privileged_psp with input as input
+}

--- a/examples/role-deny-use-privileged-psp/sync.yaml
+++ b/examples/role-deny-use-privileged-psp/sync.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: "gatekeeper-system"
+spec:
+  sync:
+    syncOnly:
+      - group: "policy"
+        version: "v1beta1"
+        kind: "PodSecurityPolicy"

--- a/examples/role-deny-use-privileged-psp/template.yaml
+++ b/examples/role-deny-use-privileged-psp/template.yaml
@@ -1,0 +1,133 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  creationTimestamp: null
+  name: roledenyuseprivilegedpsp
+spec:
+  crd:
+    spec:
+      names:
+        kind: RoleDenyUsePrivilegedPsp
+  targets:
+  - libs:
+    - |
+      package lib.core
+
+      default is_gatekeeper = false
+
+      is_gatekeeper {
+          has_field(input, "review")
+          has_field(input.review, "object")
+      }
+
+      resource = input.review.object {
+          is_gatekeeper
+      }
+
+      resource = input {
+          not is_gatekeeper
+      }
+
+      format(msg) = msg {
+          not is_gatekeeper
+      }
+
+      format(msg) = {"msg": msg} {
+          is_gatekeeper
+      }
+
+      apiVersion = resource.apiVersion
+      name = resource.metadata.name
+      kind = resource.kind
+      labels = resource.metadata.labels
+      annotations = resource.metadata.annotations
+
+      has_field(obj, field) {
+          not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
+      }
+
+      missing_field(obj, field) = true {
+          obj[field] == ""
+      }
+
+      missing_field(obj, field) = true {
+          not has_field(obj, field)
+      }
+    - |
+      package lib.rbac
+
+      import data.lib.core
+
+      rule_has_verb(rule, verb) {
+          verbs := ["*", lower(verb)]
+          verbs[_] == lower(rule.verbs[_])
+      }
+
+      rule_has_resource_type(rule, type) {
+          types := ["*", lower(type)]
+          types[_] == lower(rule.resources[_])
+      }
+
+      rule_has_resource_name(rule, name) {
+          name == rule.resourceNames[_]
+      }
+
+      rule_has_resource_name(rule, name) {
+          core.missing_field(rule, "resourceNames")
+      }
+    - |
+      package lib.security
+
+      dropped_capability(container, cap) {
+          lower(container.securityContext.capabilities.drop[_]) == lower(cap)
+      }
+
+      dropped_capability(psp, cap) {
+          lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(container, cap) {
+          lower(container.securityContext.capabilities.add[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+          lower(psp.spec.allowedCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+          lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
+      }
+    rego: |
+      package role_deny_use_privileged_psps
+
+      import data.lib.core
+      import data.lib.rbac
+      import data.lib.security
+
+      violation[msg] {
+          role_uses_privileged_psp
+
+          msg := core.format(sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]))
+      }
+
+      role_uses_privileged_psp {
+          rule := core.resource.rules[_]
+          rbac.rule_has_resource_type(rule, "podsecuritypolicies")
+          rbac.rule_has_verb(rule, "use")
+          rbac.rule_has_resource_name(rule, privileged_psps[_].metadata.name)
+      }
+
+      privileged_psps[psp] {
+          psp := data.inventory.cluster["policy/v1beta1"].PodSecurityPolicy[_]
+          psp_is_privileged(psp)
+      }
+
+      psp_is_privileged(psp) {
+          psp.spec.privileged
+      }
+
+      psp_is_privileged(psp) {
+          security.added_capability(psp, "SYS_ADMIN")
+      }
+    target: admission.k8s.gatekeeper.sh
+status: {}

--- a/examples/test-data/role-deny-use-privileged-psp.json
+++ b/examples/test-data/role-deny-use-privileged-psp.json
@@ -1,0 +1,18 @@
+{
+  "inventory": {
+    "cluster": {
+      "policy/v1beta1": {
+        "PodSecurityPolicy": {
+          "test": {
+            "metadata": {
+              "name": "test"                 
+            },
+            "spec": {
+              "privileged": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/doc/expected.md
+++ b/test/doc/expected.md
@@ -19,6 +19,7 @@
 * [PodSecurityPolicies must not allow access to the host network](#podsecuritypolicies-must-not-allow-access-to-the-host-network)
 * [PodSecurityPolicies must not allow access to the host PID namespace](#podsecuritypolicies-must-not-allow-access-to-the-host-pid-namespace)
 * [PodSecurityPolicies must require containers to not run as privileged](#podsecuritypolicies-must-require-containers-to-not-run-as-privileged)
+* [Roles must not allow use of privileged PodSecurityPolicies](#roles-must-not-allow-use-of-privileged-podsecuritypolicies)
 
 ## Warnings
 
@@ -571,6 +572,52 @@ psp_allows_privileged {
 ```
 
 _source: [../../examples/psp-deny-privileged](../../examples/psp-deny-privileged)_
+
+## Roles must not allow use of privileged PodSecurityPolicies
+
+**Severity:** Violation
+
+**Resources:** rbac.authorization.k8s.io/Role
+
+Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
+
+### Rego
+
+```rego
+package role_deny_use_privileged_psps
+
+import data.lib.core
+import data.lib.rbac
+import data.lib.security
+
+violation[msg] {
+    role_uses_privileged_psp
+
+    msg := core.format(sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]))
+}
+
+role_uses_privileged_psp {
+    rule := core.resource.rules[_]
+    rbac.rule_has_resource_type(rule, "podsecuritypolicies")
+    rbac.rule_has_verb(rule, "use")
+    rbac.rule_has_resource_name(rule, privileged_psps[_].metadata.name)
+}
+
+privileged_psps[psp] {
+    psp := data.inventory.cluster["policy/v1beta1"].PodSecurityPolicy[_]
+    psp_is_privileged(psp)
+}
+
+psp_is_privileged(psp) {
+    psp.spec.privileged
+}
+
+psp_is_privileged(psp) {
+    security.added_capability(psp, "SYS_ADMIN")
+}
+```
+
+_source: [../../examples/role-deny-use-privileged-psp](../../examples/role-deny-use-privileged-psp)_
 
 ## Deprecated Deployment and DaemonSet API
 


### PR DESCRIPTION
This adds an example policy showing using the RBAC library and Gatekeeper's sync feature to prevent workloads from using a privileged PodSecurityPolicy.