### PR TITLE
Fix unsafe "msg" variable in acceptance tests

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -2,15 +2,18 @@
 
 @test "[DOC] Generated documentation matches example documentation" {
   run ./build/konstraint doc examples --output examples/policies.md
+  [ "$status" -eq 0 ]
   git diff --quiet -- examples/policies.md
 }
 
 @test "[CREATE] Creating constraints and templates matches examples" {
   run ./build/konstraint create examples
+  [ "$status" -eq 0 ]
   git diff --quiet -- examples/
 }
 
 @test "[CREATE] Creating constraints using --output matches expected output" {
   run ./build/konstraint create test --output test
+  [ "$status" -eq 0 ]
   git diff --quiet -- test/
 }

--- a/test/src.rego
+++ b/test/src.rego
@@ -7,6 +7,6 @@ package test
 
 import data.lib.libraryA
 
-violation[msg] {
+violation["msg"] {
     true
 }

--- a/test/template_Test.yaml
+++ b/test/template_Test.yaml
@@ -10,17 +10,18 @@ spec:
         kind: Test
   targets:
   - libs:
-    - |-
+    - |
       package lib.libraryA
 
       import data.lib.libraryB
-    - package lib.libraryB
-    rego: |-
+    - |
+      package lib.libraryB
+    rego: |
       package test
 
       import data.lib.libraryA
 
-      violation[msg] {
+      violation["msg"] {
           true
       }
     target: admission.k8s.gatekeeper.sh

--- a/test/template_Test.yaml
+++ b/test/template_Test.yaml
@@ -10,13 +10,12 @@ spec:
         kind: Test
   targets:
   - libs:
-    - |
+    - |-
       package lib.libraryA
 
       import data.lib.libraryB
-    - |
-      package lib.libraryB
-    rego: |
+    - package lib.libraryB
+    rego: |-
       package test
 
       import data.lib.libraryA


### PR DESCRIPTION
Previously our acceptance tests were silently failing due to the `msg` in `violation[msg]` never being set and therefore being an unsafe variable, which caused the template and constraint to never update. This resolves that issue as well as adds exit code checks to verify Konstraint exited without errors.

edit: typos