### PR TITLE
Add parameters to lib.core

### DIFF
--- a/examples/container-deny-added-caps/template.yaml
+++ b/examples/container-deny-added-caps/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-escalation/template.yaml
+++ b/examples/container-deny-escalation/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-latest-tag/template.yaml
+++ b/examples/container-deny-latest-tag/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-privileged/template.yaml
+++ b/examples/container-deny-privileged/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-without-resource-constraints/template.yaml
+++ b/examples/container-deny-without-resource-constraints/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/lib/core.rego
+++ b/examples/lib/core.rego
@@ -39,6 +39,15 @@ group = "core" {
     not contains(apiVersion, "/")
 }
 version := gv[count(gv) - 1]
+
+parameters = input.parameters {
+    is_gatekeeper
+}
+
+parameters = data.parameters {
+   not is_gatekeeper
+}
+
 has_field(obj, field) {
     not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
 }

--- a/examples/pod-deny-host-alias/template.yaml
+++ b/examples/pod-deny-host-alias/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-host-ipc/template.yaml
+++ b/examples/pod-deny-host-ipc/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-host-network/template.yaml
+++ b/examples/pod-deny-host-network/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-host-pid/template.yaml
+++ b/examples/pod-deny-host-pid/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-without-runasnonroot/template.yaml
+++ b/examples/pod-deny-without-runasnonroot/template.yaml
@@ -81,6 +81,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -640,7 +640,7 @@ violation[msg] {
 
 missing_labels = missing {
     provided := {label | core.labels[label]}
-    required := {label | label := input.parameters.labels[_]}
+    required := {label | label := core.parameters.labels[_]}
     missing := required - provided
 }
 ```

--- a/examples/psp-deny-added-caps/template.yaml
+++ b/examples/psp-deny-added-caps/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-escalation/template.yaml
+++ b/examples/psp-deny-escalation/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-alias/template.yaml
+++ b/examples/psp-deny-host-alias/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-ipc/template.yaml
+++ b/examples/psp-deny-host-ipc/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-network/template.yaml
+++ b/examples/psp-deny-host-network/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-pid/template.yaml
+++ b/examples/psp-deny-host-pid/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-privileged/template.yaml
+++ b/examples/psp-deny-privileged/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/required-labels/src.rego
+++ b/examples/required-labels/src.rego
@@ -20,6 +20,6 @@ violation[msg] {
 
 missing_labels = missing {
     provided := {label | core.labels[label]}
-    required := {label | label := input.parameters.labels[_]}
+    required := {label | label := core.parameters.labels[_]}
     missing := required - provided
 }

--- a/examples/required-labels/src_test.rego
+++ b/examples/required-labels/src_test.rego
@@ -13,13 +13,17 @@ test_not_missing {
     count(missing) == 0
 }
 
-test_missing {
+test_missing_gk {
     in := {
-        "metadata": {
-            "labels": {
-                "test": "test"
+        "review": {
+            "object": {
+                "metadata": {
+                    "labels": {
+                        "test": "test"
+                    }
+                }
             }
-        },
+        },        
         "parameters": {
             "labels": ["one", "two"]
         }
@@ -27,4 +31,20 @@ test_missing {
 
     missing := missing_labels with input as in
     count(missing) == 2
+}
+
+test_missing_not_gk {
+    in := {
+        "metadata": {
+            "labels": {
+                "test": "test"
+            }
+        }
+    }
+    p := {
+        "labels": ["test", "two"]
+    }
+
+    missing := missing_labels with input as in with data.parameters as p
+    count(missing) == 1
 }

--- a/examples/required-labels/template.yaml
+++ b/examples/required-labels/template.yaml
@@ -59,6 +59,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }
@@ -86,7 +95,7 @@ spec:
 
       missing_labels = missing {
           provided := {label | core.labels[label]}
-          required := {label | label := input.parameters.labels[_]}
+          required := {label | label := core.parameters.labels[_]}
           missing := required - provided
       }
     target: admission.k8s.gatekeeper.sh

--- a/examples/role-deny-use-privileged-psp/template.yaml
+++ b/examples/role-deny-use-privileged-psp/template.yaml
@@ -52,6 +52,15 @@ spec:
           not contains(apiVersion, "/")
       }
       version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -302,12 +302,12 @@ func parseDirectory(directory string) ([]Rego, error) {
 }
 
 func getBodyParamNames(rules []*ast.Rule) []string {
-	r := regexp.MustCompile(`input\.parameters\.([a-zA-Z0-9_-]+)`)
+	r := regexp.MustCompile(`(core|input)\.parameters\.([a-zA-Z0-9_-]+)`)
 	var bodyParams []string
 	for _, rule := range rules {
 		matches := r.FindAllStringSubmatch(rule.Body.String(), -1)
 		for _, match := range matches {
-			bodyParams = append(bodyParams, match[1]) // the 0 index is the full match, we only care about the first group
+			bodyParams = append(bodyParams, match[2]) // the 0 index is the full match, we only care about the second group
 		}
 	}
 	bodyParams = dedupe(bodyParams) // possible a param is referenced more than once

--- a/internal/rego/rego_test.go
+++ b/internal/rego/rego_test.go
@@ -162,12 +162,32 @@ func TestGetPolicyID_Null(t *testing.T) {
 	}
 }
 
-func TestGetBodyParamNames(t *testing.T) {
+func TestGetBodyParamNamesFromInput(t *testing.T) {
 	ruleString := `violation[msg] {
 	foo := "bar"
 	bar := input.parameters.baz
 	baz := input.parameters.foobars[_]
 	box := input.parameters.baz
+}`
+
+	rule, err := ast.ParseRule(ruleString)
+	if err != nil {
+		t.Fatalf("parse rule: %s", err)
+	}
+
+	expected := []string{"baz", "foobars"}
+	actual := getBodyParamNames([]*ast.Rule{rule})
+	if !(reflect.DeepEqual(expected, actual)) {
+		t.Errorf("unexpected bodyParams. expected %+v, actual %+v", expected, actual)
+	}
+}
+
+func TestGetBodyParamNamesFromCore(t *testing.T) {
+	ruleString := `violation[msg] {
+	foo := "bar"
+	bar := core.parameters.baz
+	baz := core.parameters.foobars[_]
+	box := core.parameters.baz
 }`
 
 	rule, err := ast.ParseRule(ruleString)


### PR DESCRIPTION
This adds a `parameters` rule to lib.core which allows the parameters to be accessed whether they're sent from Gatekeeper or through Conftest's `--data` flag. In order to not break any existing policies, the regex was updated to match on either `core.parameters` or `input.parameters`.