### PR TITLE
Only trigger Docker image push on v*.*.* tags

### DIFF
--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -1,8 +1,6 @@
 name: Push Tagged Container
 on:
   push:
-    branches:
-    - main
     tags:
     - v*.*.*
 


### PR DESCRIPTION
The Docker image push was incorrectly being triggered on every push to `main`.