### PR TITLE
Support @matchlabels annotating rule

### DIFF
--- a/docs/constraint_creation.md
+++ b/docs/constraint_creation.md
@@ -78,11 +78,11 @@ The comment block is also what is used when generating documentation via the `do
 
 ### Annotating rules for matchers
 
-- `@kinds` generates `constraint.spec.match.kinds`. The allowed format is whitespace-separated `<group>/<kind>` list.
+- `@kinds` generates `constraint.spec.match.kinds`. The allowed format is space-separated `<group>/<kind>` list.
     ```
     # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
     ```
-- `@matchlabels` generates `constraint.spec.match.labelSelector.matchLabels`. The allowed format is whitespace-separated `<label-key>=<label-val>` list.
+- `@matchlabels` generates `constraint.spec.match.labelSelector.matchLabels`. The allowed format is space-separated `<label-key>=<label-val>` list.
     ```
     # @matchlabels app.kubernetes.io/name=mysql app.kubernetes.io/version=5.8
     ```

--- a/docs/constraint_creation.md
+++ b/docs/constraint_creation.md
@@ -48,7 +48,7 @@ This comment block should:
 - Include a human readable description of what the policy does.
 - Set the matchers used when generating the Constraints.
 
-It may also specify the enforcment action (either `deny` or `dryrun`) that Gatekeeper should take when a resource violates the constraint. If no enforcement action is specified, Konstraint defaults to using `deny` to align with Gatekeeper's default action. If the enforcement is set to `dryrun`, the policy will be skipped in the documentation generation.
+It may also specify the enforcement action (either `deny` or `dryrun`) that Gatekeeper should take when a resource violates the constraint. If no enforcement action is specified, Konstraint defaults to using `deny` to align with Gatekeeper's default action. If the enforcement is set to `dryrun`, the policy will be skipped in the documentation generation.
 
 ```rego
 # @title Pods must not run with access to the host IPC
@@ -75,6 +75,17 @@ pod_has_hostipc {
 ```
 
 The comment block is also what is used when generating documentation via the `doc` command.
+
+### Annotating rules for matchers
+
+- `@kinds` generates `constraint.spec.match.kinds`. The allowed format is whitespace-separated `<group>/<kind>` list.
+    ```
+    # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+    ```
+- `@matchlabels` generates `constraint.spec.match.labelSelector.matchLabels`. The allowed format is whitespace-separated `<label-key>=<label-val>` list.
+    ```
+    # @matchlabels app.kubernetes.io/name=mysql app.kubernetes.io/version=5.8
+    ```
 
 ## Using Input Parameters
 

--- a/examples/container-deny-privileged-if-tenant/constraint.yaml
+++ b/examples/container-deny-privileged-if-tenant/constraint.yaml
@@ -1,0 +1,18 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: ContainerDenyPrivilegedIfTenant
+metadata:
+  name: containerdenyprivilegediftenant
+spec:
+  match:
+    kinds:
+    - apiGroups:
+      - apps
+      - ""
+      kinds:
+      - DaemonSet
+      - Deployment
+      - StatefulSet
+      - Pod
+    labelSelector:
+      matchLabels:
+        is-tenant: "true"

--- a/examples/container-deny-privileged-if-tenant/src.rego
+++ b/examples/container-deny-privileged-if-tenant/src.rego
@@ -1,0 +1,33 @@
+# @title Tenants' containers must not run as privileged
+#
+# Privileged containers can easily escalate to root privileges on the node. As
+# such containers running as privileged or with sufficient capabilities granted
+# to obtain the same effect are not allowed if they are labeled as tenant.
+# To take advantage of this policy, it must be combined with another policy
+# that enforces the 'is-tenant' label.
+# This is the example for @matchlabels.
+#
+# @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+# @matchlabels is-tenant=true
+package container_deny_privileged_if_tenant
+
+import data.lib.core
+import data.lib.pods
+import data.lib.security
+
+policyID := "P2006"
+
+violation[msg] {
+    pods.containers[container]
+    container_is_privileged(container)
+
+    msg = core.format_with_id(sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+}
+
+container_is_privileged(container) {
+    container.securityContext.privileged
+}
+
+container_is_privileged(container) {
+    security.added_capability(container, "CAP_SYS_ADMIN")
+}

--- a/examples/container-deny-privileged-if-tenant/src_test.rego
+++ b/examples/container-deny-privileged-if-tenant/src_test.rego
@@ -1,0 +1,23 @@
+package container_deny_privileged
+
+test_privileged_true {
+    input := {"securityContext": {"privileged": true}}
+
+    container_is_privileged(input)
+}
+
+test_privileged_false {
+    input := {"securityContext": {"privileged": false}}
+
+    not container_is_privileged(input)
+}
+
+test_added_capability {
+    input := {
+        "securityContext": {
+            "capabilities": {"add": ["CAP_SYS_ADMIN"]}
+        }
+    }
+
+    container_is_privileged(input)
+}

--- a/examples/container-deny-privileged-if-tenant/template.yaml
+++ b/examples/container-deny-privileged-if-tenant/template.yaml
@@ -1,0 +1,150 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  creationTimestamp: null
+  name: containerdenyprivilegediftenant
+spec:
+  crd:
+    spec:
+      names:
+        kind: ContainerDenyPrivilegedIfTenant
+  targets:
+  - libs:
+    - |-
+      package lib.core
+
+      default is_gatekeeper = false
+
+      is_gatekeeper {
+          has_field(input, "review")
+          has_field(input.review, "object")
+      }
+
+      resource = input.review.object {
+          is_gatekeeper
+      }
+
+      resource = input {
+          not is_gatekeeper
+      }
+
+      format(msg) = {"msg": msg} {
+          true
+      }
+
+      format_with_id(msg, id) = msg_fmt {
+          msg_fmt := {
+              "msg": sprintf("%s: %s", [id, msg]),
+              "details": {"policyID": id}
+          }
+      }
+
+      apiVersion = resource.apiVersion
+      name = resource.metadata.name
+      kind = resource.kind
+      labels = resource.metadata.labels
+      annotations = resource.metadata.annotations
+      gv := split(apiVersion, "/")
+      group = gv[0] {
+          contains(apiVersion, "/")
+      }
+      group = "core" {
+          not contains(apiVersion, "/")
+      }
+      version := gv[count(gv) - 1]
+
+      parameters = input.parameters {
+          is_gatekeeper
+      }
+
+      parameters = data.parameters {
+         not is_gatekeeper
+      }
+
+      has_field(obj, field) {
+          not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
+      }
+
+      missing_field(obj, field) = true {
+          obj[field] == ""
+      }
+
+      missing_field(obj, field) = true {
+          not has_field(obj, field)
+      }
+    - |-
+      package lib.pods
+
+      import data.lib.core
+
+      default pod = false
+
+      pod = core.resource.spec.template {
+          pod_templates := ["daemonset","deployment","job","replicaset","replicationcontroller","statefulset"]
+          lower(core.kind) == pod_templates[_]
+      }
+
+      pod = core.resource {
+          lower(core.kind) == "pod"
+      }
+
+      pod = core.resource.spec.jobTemplate.spec.template {
+          lower(core.kind) == "cronjob"
+      }
+
+      containers[container] {
+          keys = {"containers", "initContainers"}
+          all_containers = [c | keys[k]; c = pod.spec[k][_]]
+          container = all_containers[_]
+      }
+
+      volumes[volume] {
+          volume = pod.spec.volumes[_]
+      }
+    - |-
+      package lib.security
+
+      dropped_capability(container, cap) {
+          lower(container.securityContext.capabilities.drop[_]) == lower(cap)
+      }
+
+      dropped_capability(psp, cap) {
+          lower(psp.spec.requiredDropCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(container, cap) {
+          lower(container.securityContext.capabilities.add[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+          lower(psp.spec.allowedCapabilities[_]) == lower(cap)
+      }
+
+      added_capability(psp, cap) {
+          lower(psp.spec.defaultAddCapabilities[_]) == lower(cap)
+      }
+    rego: |-
+      package container_deny_privileged_if_tenant
+
+      import data.lib.core
+      import data.lib.pods
+      import data.lib.security
+
+      policyID := "P2006"
+
+      violation[msg] {
+          pods.containers[container]
+          container_is_privileged(container)
+
+          msg = core.format_with_id(sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+      }
+
+      container_is_privileged(container) {
+          container.securityContext.privileged
+      }
+
+      container_is_privileged(container) {
+          security.added_capability(container, "CAP_SYS_ADMIN")
+      }
+    target: admission.k8s.gatekeeper.sh
+status: {}

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -34,6 +34,8 @@
 
 **Resources:** Any Resource
 
+**MatchLabels:** *
+
 **Parameters:**
 
 * labels: array of string
@@ -73,6 +75,8 @@ _source: [required-labels](required-labels)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
+**MatchLabels:** *
+
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
@@ -107,6 +111,8 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+
+**MatchLabels:** *
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -144,6 +150,8 @@ _source: [container-deny-escalation](container-deny-escalation)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+
+**MatchLabels:** *
 
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
@@ -184,6 +192,8 @@ _source: [container-deny-privileged](container-deny-privileged)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
+**MatchLabels:** *
+
 Pods that can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
 
@@ -215,6 +225,8 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+
+**MatchLabels:** *
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -248,6 +260,8 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
+**MatchLabels:** *
+
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
 
@@ -279,6 +293,8 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+
+**MatchLabels:** *
 
 Pods that can access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -313,6 +329,8 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
+**MatchLabels:** *
+
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
 
@@ -345,6 +363,8 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 **Severity:** Violation
 
 **Resources:** policy/PodSecurityPolicy
+
+**MatchLabels:** *
 
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -380,6 +400,8 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:** policy/PodSecurityPolicy
+
+**MatchLabels:** *
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -418,6 +440,8 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 
 **Resources:** policy/PodSecurityPolicy
 
+**MatchLabels:** *
+
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
 
@@ -450,6 +474,8 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
 **Resources:** policy/PodSecurityPolicy
 
+**MatchLabels:** *
+
 Allowing pods to access the host IPC can read memory of
 the other containers, breaking that security boundary.
 
@@ -481,6 +507,8 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 **Severity:** Violation
 
 **Resources:** policy/PodSecurityPolicy
+
+**MatchLabels:** *
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -515,6 +543,8 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 
 **Resources:** policy/PodSecurityPolicy
 
+**MatchLabels:** *
+
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
@@ -548,6 +578,8 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
 **Resources:** policy/PodSecurityPolicy
 
+**MatchLabels:** *
+
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
 
@@ -579,6 +611,8 @@ _source: [psp-deny-privileged](psp-deny-privileged)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+
+**MatchLabels:** *
 
 Using the latest tag on images can cause unexpected problems in production. By specifying a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
@@ -617,6 +651,8 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
+**MatchLabels:** *
+
 Resource constraints on containers ensure that a given workload does not take up more resources than it requires
 and potentially starve other applications that need to run.
 
@@ -652,6 +688,8 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 **Severity:** Violation
 
 **Resources:** rbac.authorization.k8s.io/Role
+
+**MatchLabels:** *
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
 
@@ -701,6 +739,8 @@ _source: [role-deny-use-privileged-psp](role-deny-use-privileged-psp)_
 
 **Resources:** apps/DaemonSet apps/Deployment
 
+**MatchLabels:** *
+
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
 the version for both of these resources must be `apps/v1`.
@@ -730,6 +770,8 @@ _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 **Severity:** Warning
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+
+**MatchLabels:** *
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
@@ -768,6 +810,8 @@ _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 **Severity:** Warning
 
 **Resources:** policy/PodSecurityPolicy
+
+**MatchLabels:** *
 
 Allowing pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -21,6 +21,7 @@
 * [P2001: Images must not use the latest tag](#p2001-images-must-not-use-the-latest-tag)
 * [P2002: Containers must define resource constraints](#p2002-containers-must-define-resource-constraints)
 * [P2005: Roles must not allow use of privileged PodSecurityPolicies](#p2005-roles-must-not-allow-use-of-privileged-podsecuritypolicies)
+* [P2006: Tenants' containers must not run as privileged](#p2006-tenants'-containers-must-not-run-as-privileged)
 
 ## Warnings
 
@@ -33,8 +34,6 @@
 **Severity:** Violation
 
 **Resources:** Any Resource
-
-**MatchLabels:** *
 
 **Parameters:**
 
@@ -75,8 +74,6 @@ _source: [required-labels](required-labels)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-**MatchLabels:** *
-
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
@@ -111,8 +108,6 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
-**MatchLabels:** *
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -150,8 +145,6 @@ _source: [container-deny-escalation](container-deny-escalation)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
-**MatchLabels:** *
 
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
@@ -192,8 +185,6 @@ _source: [container-deny-privileged](container-deny-privileged)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-**MatchLabels:** *
-
 Pods that can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
 
@@ -225,8 +216,6 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
-**MatchLabels:** *
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -260,8 +249,6 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-**MatchLabels:** *
-
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
 
@@ -293,8 +280,6 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
-**MatchLabels:** *
 
 Pods that can access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -329,8 +314,6 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-**MatchLabels:** *
-
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
 
@@ -363,8 +346,6 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 **Severity:** Violation
 
 **Resources:** policy/PodSecurityPolicy
-
-**MatchLabels:** *
 
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -400,8 +381,6 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:** policy/PodSecurityPolicy
-
-**MatchLabels:** *
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -440,8 +419,6 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 
 **Resources:** policy/PodSecurityPolicy
 
-**MatchLabels:** *
-
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
 
@@ -474,8 +451,6 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
 **Resources:** policy/PodSecurityPolicy
 
-**MatchLabels:** *
-
 Allowing pods to access the host IPC can read memory of
 the other containers, breaking that security boundary.
 
@@ -507,8 +482,6 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 **Severity:** Violation
 
 **Resources:** policy/PodSecurityPolicy
-
-**MatchLabels:** *
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -543,8 +516,6 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 
 **Resources:** policy/PodSecurityPolicy
 
-**MatchLabels:** *
-
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
@@ -578,8 +549,6 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
 **Resources:** policy/PodSecurityPolicy
 
-**MatchLabels:** *
-
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
 
@@ -611,8 +580,6 @@ _source: [psp-deny-privileged](psp-deny-privileged)_
 **Severity:** Violation
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
-**MatchLabels:** *
 
 Using the latest tag on images can cause unexpected problems in production. By specifying a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
@@ -651,8 +618,6 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 
-**MatchLabels:** *
-
 Resource constraints on containers ensure that a given workload does not take up more resources than it requires
 and potentially starve other applications that need to run.
 
@@ -688,8 +653,6 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 **Severity:** Violation
 
 **Resources:** rbac.authorization.k8s.io/Role
-
-**MatchLabels:** *
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
 
@@ -733,13 +696,55 @@ psp_is_privileged(psp) {
 
 _source: [role-deny-use-privileged-psp](role-deny-use-privileged-psp)_
 
+## P2006: Tenants' containers must not run as privileged
+
+**Severity:** Violation
+
+**Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+
+**MatchLabels:** is-tenant=true
+
+Privileged containers can easily escalate to root privileges on the node. As
+such containers running as privileged or with sufficient capabilities granted
+to obtain the same effect are not allowed if they are labeled as tenant.
+To take advantage of this policy, it must be combined with another policy
+that enforces the 'is-tenant' label.
+This is the example for @matchlabels.
+
+### Rego
+
+```rego
+package container_deny_privileged_if_tenant
+
+import data.lib.core
+import data.lib.pods
+import data.lib.security
+
+policyID := "P2006"
+
+violation[msg] {
+    pods.containers[container]
+    container_is_privileged(container)
+
+    msg = core.format_with_id(sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+}
+
+container_is_privileged(container) {
+    container.securityContext.privileged
+}
+
+container_is_privileged(container) {
+    security.added_capability(container, "CAP_SYS_ADMIN")
+}
+```
+
+_source: [container-deny-privileged-if-tenant](container-deny-privileged-if-tenant)_
+
 ## P0001: Deprecated Deployment and DaemonSet API
 
 **Severity:** Warning
 
 **Resources:** apps/DaemonSet apps/Deployment
-
-**MatchLabels:** *
 
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
@@ -770,8 +775,6 @@ _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 **Severity:** Warning
 
 **Resources:** apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-
-**MatchLabels:** *
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
@@ -810,8 +813,6 @@ _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 **Severity:** Warning
 
 **Resources:** policy/PodSecurityPolicy
-
-**MatchLabels:** *
 
 Allowing pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -184,7 +184,10 @@ func getConstraint(violation rego.Rego) (unstructured.Unstructured, error) {
 		}
 	}
 
-	matchers := violation.Matchers()
+	matchers, err := violation.Matchers()
+	if err != nil {
+		return constraint, err
+	}
 	if len(matchers.KindMatchers) == 0 {
 		return constraint, nil
 	}

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -140,9 +140,6 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 			resources = "Any Resource"
 		}
 		matchLabels := matchers.MatchLabelsMatcher.String()
-		if matchLabels == "" {
-			matchLabels = "*"
-		}
 
 		header := Header{
 			Title:       documentTitle,

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -131,7 +131,10 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 		anchor := strings.ToLower(strings.ReplaceAll(documentTitle, " ", "-"))
 		anchor = strings.ReplaceAll(anchor, ":", "")
 
-		matchers := policy.Matchers()
+		matchers, err := policy.Matchers()
+		if err != nil {
+			return nil, err
+		}
 		resources := matchers.KindMatchers.String()
 		if resources == "" {
 			resources = "Any Resource"

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -19,6 +19,7 @@ type Header struct {
 	Title       string
 	Description string
 	Resources   string
+	MatchLabels string
 	Anchor      string
 	Parameters  []rego.Parameter
 }
@@ -130,15 +131,21 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 		anchor := strings.ToLower(strings.ReplaceAll(documentTitle, " ", "-"))
 		anchor = strings.ReplaceAll(anchor, ":", "")
 
-		matchers := policy.Matchers().String()
-		if matchers == "" {
-			matchers = "Any Resource"
+		matchers := policy.Matchers()
+		resources := matchers.KindMatchers.String()
+		if resources == "" {
+			resources = "Any Resource"
+		}
+		matchLabels := matchers.MatchLabelsMatcher.String()
+		if matchLabels == "" {
+			matchLabels = "*"
 		}
 
 		header := Header{
 			Title:       documentTitle,
 			Description: policy.Description(),
-			Resources:   matchers,
+			Resources:   resources,
+			MatchLabels: matchLabels,
 			Anchor:      anchor,
 			Parameters:  policy.Parameters(),
 		}

--- a/internal/commands/document_template.go
+++ b/internal/commands/document_template.go
@@ -17,6 +17,8 @@ const docTemplate = `# Policies
 
 **Resources:** {{ .Header.Resources }}
 
+**MatchLabels** {{ .Header.MatchLabels }}
+
 {{- if .Header.Parameters }}
 
 **Parameters:**

--- a/internal/commands/document_template.go
+++ b/internal/commands/document_template.go
@@ -17,7 +17,10 @@ const docTemplate = `# Policies
 
 **Resources:** {{ .Header.Resources }}
 
+{{- if .Header.MatchLabels }}
+
 **MatchLabels:** {{ .Header.MatchLabels }}
+{{- end }}
 
 {{- if .Header.Parameters }}
 

--- a/internal/commands/document_template.go
+++ b/internal/commands/document_template.go
@@ -17,7 +17,7 @@ const docTemplate = `# Policies
 
 **Resources:** {{ .Header.Resources }}
 
-**MatchLabels** {{ .Header.MatchLabels }}
+**MatchLabels:** {{ .Header.MatchLabels }}
 
 {{- if .Header.Parameters }}
 

--- a/internal/rego/matchers.go
+++ b/internal/rego/matchers.go
@@ -1,12 +1,15 @@
 package rego
 
 import (
+	"fmt"
+	"log"
 	"strings"
 )
 
 // Matchers are all of the matchers that can be applied to constraints.
 type Matchers struct {
-	KindMatchers []KindMatcher
+	KindMatchers       []KindMatcher
+	MatchLabelsMatcher MatchLabelsMatcher
 }
 
 func (m Matchers) String() string {
@@ -25,12 +28,22 @@ type KindMatcher struct {
 	Kind     string
 }
 
+// MatchLabelsMatcher is the matcher to generate `constraints.spec.match.labelSelector.matchLabels`.
+type MatchLabelsMatcher map[string]string
+
 // Matchers returns all of the matchers found in the rego file.
 func (r Rego) Matchers() Matchers {
 	var matchers Matchers
 	for _, comment := range r.comments {
 		if strings.HasPrefix(comment, "@kinds") {
 			matchers.KindMatchers = getKindMatchers(comment)
+		}
+		if strings.HasPrefix(comment, "@matchlabels") {
+			var err error
+			matchers.MatchLabelsMatcher, err = getMatchLabelsMatcher(comment)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 
@@ -55,4 +68,19 @@ func getKindMatchers(comment string) []KindMatcher {
 	}
 
 	return kindMatchers
+}
+
+func getMatchLabelsMatcher(comment string) (MatchLabelsMatcher, error) {
+	matcher := make(map[string]string)
+
+	matcherText := strings.TrimSpace(strings.SplitAfter(comment, "@matchlabels")[1])
+
+	for _, token := range strings.Fields(matcherText) {
+		split := strings.Split(token, "=")
+		if len(split) != 2 {
+			return nil, fmt.Errorf("invalid @matchlabels annotation token: %s", token)
+		}
+		matcher[split[0]] = split[1]
+	}
+	return matcher, nil
 }

--- a/internal/rego/matchers.go
+++ b/internal/rego/matchers.go
@@ -8,13 +8,16 @@ import (
 
 // Matchers are all of the matchers that can be applied to constraints.
 type Matchers struct {
-	KindMatchers       []KindMatcher
+	KindMatchers       KindMatchers
 	MatchLabelsMatcher MatchLabelsMatcher
 }
 
-func (m Matchers) String() string {
+// KindMatchers is the slice of KindMatcher
+type KindMatchers []KindMatcher
+
+func (k KindMatchers) String() string {
 	var result string
-	for _, kindMatcher := range m.KindMatchers {
+	for _, kindMatcher := range k {
 		result += kindMatcher.APIGroup + "/" + kindMatcher.Kind + " "
 	}
 	result = strings.TrimSpace(result)
@@ -30,6 +33,14 @@ type KindMatcher struct {
 
 // MatchLabelsMatcher is the matcher to generate `constraints.spec.match.labelSelector.matchLabels`.
 type MatchLabelsMatcher map[string]string
+
+func (m MatchLabelsMatcher) String() string {
+	var result string
+	for k, v := range m {
+		result += fmt.Sprintf("%s=%s ", k, v)
+	}
+	return strings.TrimSpace(result)
+}
 
 // Matchers returns all of the matchers found in the rego file.
 func (r Rego) Matchers() Matchers {

--- a/internal/rego/matchers.go
+++ b/internal/rego/matchers.go
@@ -2,7 +2,6 @@ package rego
 
 import (
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -43,7 +42,7 @@ func (m MatchLabelsMatcher) String() string {
 }
 
 // Matchers returns all of the matchers found in the rego file.
-func (r Rego) Matchers() Matchers {
+func (r Rego) Matchers() (Matchers, error) {
 	var matchers Matchers
 	for _, comment := range r.comments {
 		if strings.HasPrefix(comment, "@kinds") {
@@ -53,12 +52,12 @@ func (r Rego) Matchers() Matchers {
 			var err error
 			matchers.MatchLabelsMatcher, err = getMatchLabelsMatcher(comment)
 			if err != nil {
-				log.Fatal(err)
+				return matchers, err
 			}
 		}
 	}
 
-	return matchers
+	return matchers, nil
 }
 
 func getKindMatchers(comment string) []KindMatcher {

--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -24,3 +24,23 @@ func TestGetKindMatchers(t *testing.T) {
 		t.Errorf("Unexpected KindMatchers. expected %v, actual %v.", expected, actual)
 	}
 }
+
+func TestGetMatchLabelsMatcher(t *testing.T) {
+	comments := []string{
+		"@matchlabels team=a app.kubernetes.io/name=test",
+	}
+	rego := Rego{
+		comments: comments,
+	}
+
+	expected := MatchLabelsMatcher{
+		"team":                   "a",
+		"app.kubernetes.io/name": "test",
+	}
+
+	actual := rego.Matchers().MatchLabelsMatcher
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected MatchLabelMatcher. expected %v, actual %v.", expected, actual)
+	}
+}

--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -13,7 +13,7 @@ func TestGetKindMatchers(t *testing.T) {
 		comments: comments,
 	}
 
-	expected := []KindMatcher{
+	expected := KindMatchers{
 		{APIGroup: "core", Kind: "Pod"},
 		{APIGroup: "apps", Kind: "Deployment"},
 	}

--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -18,7 +18,11 @@ func TestGetKindMatchers(t *testing.T) {
 		{APIGroup: "apps", Kind: "Deployment"},
 	}
 
-	actual := rego.Matchers().KindMatchers
+	matchers, err := rego.Matchers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := matchers.KindMatchers
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Unexpected KindMatchers. expected %v, actual %v.", expected, actual)
@@ -38,7 +42,11 @@ func TestGetMatchLabelsMatcher(t *testing.T) {
 		"app.kubernetes.io/name": "test",
 	}
 
-	actual := rego.Matchers().MatchLabelsMatcher
+	matchers, err := rego.Matchers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := matchers.MatchLabelsMatcher
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Unexpected MatchLabelMatcher. expected %v, actual %v.", expected, actual)


### PR DESCRIPTION
https://github.com/plexsystems/konstraint/issues/93

```rego
# @matchlabels app=a team=b
package foo

import data.lib.core
...
```
↓
```yaml
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: Foo
metadata:
  name: foo
spec:
  match:
    labelSelector:
      matchLabels:
        app: a
        team: b
```