### PR TITLE
Add Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,14 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "monthly"
   - package-ecosystem: "docker"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "monthly"
   - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Helps keep GitHub Actions and other dependencies up-to-date. Set Go and Docker to monthly checks to reduce noise. GitHub Actions to weekly as they are updated less often yet also have more consequential updates, generally.

Enable Dependabot under this repo's settings: `/plexsystems/konstraint/network/updates` before merging this PR to use this configuration. Dependabot will validate the syntax of the file as a status check on the PR.