### PR TITLE
Bump Golang from 1.14 to 1.15

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.14.x'
+          go-version: '1.15.x'
 
       - name: checkout source
         uses: actions/checkout@v2

--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.15.x
     - name: checkout
       uses: actions/checkout@v2
     - name: unit test

--- a/.github/workflows/update_cli_docs.yaml
+++ b/.github/workflows/update_cli_docs.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.14.x'
+          go-version: '1.15.x'
 
       - name: checkout source
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine AS build
+FROM golang:1.15.6-alpine AS build
 WORKDIR /go/src/github.com/plexsystems/konstraint
 COPY go.mod .
 COPY go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plexsystems/konstraint
 
-go 1.14
+go 1.15
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
1.15 has been available for 6 months, it makes sense to update. 

Supersedes #98 