### PR TITLE
Remove data.parameters from lib.core

### DIFF
--- a/examples/container-deny-added-caps/template.yaml
+++ b/examples/container-deny-added-caps/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-escalation/template.yaml
+++ b/examples/container-deny-escalation/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-latest-tag/template.yaml
+++ b/examples/container-deny-latest-tag/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-privileged-if-tenant/template.yaml
+++ b/examples/container-deny-privileged-if-tenant/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-privileged/template.yaml
+++ b/examples/container-deny-privileged/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/container-deny-without-resource-constraints/template.yaml
+++ b/examples/container-deny-without-resource-constraints/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/lib/core.rego
+++ b/examples/lib/core.rego
@@ -40,14 +40,6 @@ group = "core" {
 }
 version := gv[count(gv) - 1]
 
-parameters = input.parameters {
-    is_gatekeeper
-}
-
-parameters = data.parameters {
-   not is_gatekeeper
-}
-
 has_field(obj, field) {
     not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
 }

--- a/examples/pod-deny-host-alias/template.yaml
+++ b/examples/pod-deny-host-alias/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-host-ipc/template.yaml
+++ b/examples/pod-deny-host-ipc/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-host-network/template.yaml
+++ b/examples/pod-deny-host-network/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-host-pid/template.yaml
+++ b/examples/pod-deny-host-pid/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/pod-deny-without-runasnonroot/template.yaml
+++ b/examples/pod-deny-without-runasnonroot/template.yaml
@@ -82,14 +82,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -61,7 +61,7 @@ violation[msg] {
 
 missing_labels = missing {
     provided := {label | core.labels[label]}
-    required := {label | label := core.parameters.labels[_]}
+    required := {label | label := input.parameters.labels[_]}
     missing := required - provided
 }
 ```

--- a/examples/psp-deny-added-caps/template.yaml
+++ b/examples/psp-deny-added-caps/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-escalation/template.yaml
+++ b/examples/psp-deny-escalation/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-alias/template.yaml
+++ b/examples/psp-deny-host-alias/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-ipc/template.yaml
+++ b/examples/psp-deny-host-ipc/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-network/template.yaml
+++ b/examples/psp-deny-host-network/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-host-pid/template.yaml
+++ b/examples/psp-deny-host-pid/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/psp-deny-privileged/template.yaml
+++ b/examples/psp-deny-privileged/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }

--- a/examples/required-labels/src.rego
+++ b/examples/required-labels/src.rego
@@ -20,6 +20,6 @@ violation[msg] {
 
 missing_labels = missing {
     provided := {label | core.labels[label]}
-    required := {label | label := core.parameters.labels[_]}
+    required := {label | label := input.parameters.labels[_]}
     missing := required - provided
 }

--- a/examples/required-labels/src_test.rego
+++ b/examples/required-labels/src_test.rego
@@ -32,19 +32,3 @@ test_missing_gk {
     missing := missing_labels with input as in
     count(missing) == 2
 }
-
-test_missing_not_gk {
-    in := {
-        "metadata": {
-            "labels": {
-                "test": "test"
-            }
-        }
-    }
-    p := {
-        "labels": ["test", "two"]
-    }
-
-    missing := missing_labels with input as in with data.parameters as p
-    count(missing) == 1
-}

--- a/examples/required-labels/template.yaml
+++ b/examples/required-labels/template.yaml
@@ -60,14 +60,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }
@@ -95,7 +87,7 @@ spec:
 
       missing_labels = missing {
           provided := {label | core.labels[label]}
-          required := {label | label := core.parameters.labels[_]}
+          required := {label | label := input.parameters.labels[_]}
           missing := required - provided
       }
     target: admission.k8s.gatekeeper.sh

--- a/examples/role-deny-use-privileged-psp/template.yaml
+++ b/examples/role-deny-use-privileged-psp/template.yaml
@@ -53,14 +53,6 @@ spec:
       }
       version := gv[count(gv) - 1]
 
-      parameters = input.parameters {
-          is_gatekeeper
-      }
-
-      parameters = data.parameters {
-         not is_gatekeeper
-      }
-
       has_field(obj, field) {
           not object.get(obj, field, "N_DEFINED") == "N_DEFINED"
       }


### PR DESCRIPTION
Currently Gaekeeper does not accept any policies that use the lib.core
in the examples folder due to the data.parameters reference. This
removes that reference until the issue has been fixed upstream.

Fixes #108 