### PR TITLE
Support @namespaces and @excludednamespaces annotating rule

### DIFF
--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -214,6 +214,13 @@ func getConstraint(violation rego.Rego) (unstructured.Unstructured, error) {
 		}
 	}
 
+	if len(matchers.NamespaceMatchers) != 0 {
+		err := setNamespaceMatcher(&constraint, matchers.NamespaceMatchers)
+		if err != nil {
+			return constraint, err
+		}
+	}
+
 	return constraint, nil
 }
 
@@ -255,6 +262,13 @@ func setKindMatcher(constraint *unstructured.Unstructured, kindMatchers []rego.K
 func setMatchLabelsMatcher(constraint *unstructured.Unstructured, matcher rego.MatchLabelsMatcher) error {
 	if err := unstructured.SetNestedStringMap(constraint.Object, matcher, "spec", "match", "labelSelector", "matchLabels"); err != nil {
 		return fmt.Errorf("set constraint labelSelector.matchLabels matchers: %w", err)
+	}
+	return nil
+}
+
+func setNamespaceMatcher(constraint *unstructured.Unstructured, matcher rego.NamespaceMatchers) error {
+	if err := unstructured.SetNestedStringSlice(constraint.Object, matcher, "spec", "match", "namespaces"); err != nil {
+		return fmt.Errorf("set constraint namespace matchers: %w", err)
 	}
 	return nil
 }

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -214,8 +214,8 @@ func getConstraint(violation rego.Rego) (unstructured.Unstructured, error) {
 		}
 	}
 
-	if len(matchers.NamespaceMatchers) != 0 {
-		err := setNamespaceMatcher(&constraint, matchers.NamespaceMatchers)
+	if len(matchers.NamespacesMatchers) != 0 {
+		err := setNamespacesMatcher(&constraint, matchers.NamespacesMatchers)
 		if err != nil {
 			return constraint, err
 		}
@@ -273,7 +273,7 @@ func setMatchLabelsMatcher(constraint *unstructured.Unstructured, matcher rego.M
 	return nil
 }
 
-func setNamespaceMatcher(constraint *unstructured.Unstructured, matcher rego.NamespaceMatchers) error {
+func setNamespacesMatcher(constraint *unstructured.Unstructured, matcher rego.NamespacesMatchers) error {
 	if err := unstructured.SetNestedStringSlice(constraint.Object, matcher, "spec", "match", "namespaces"); err != nil {
 		return fmt.Errorf("set constraint namespace matchers: %w", err)
 	}

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -221,6 +221,13 @@ func getConstraint(violation rego.Rego) (unstructured.Unstructured, error) {
 		}
 	}
 
+	if len(matchers.ExcludedNamespacesMatchers) != 0 {
+		err := setExcludedNamespacesMatcher(&constraint, matchers.ExcludedNamespacesMatchers)
+		if err != nil {
+			return constraint, err
+		}
+	}
+
 	return constraint, nil
 }
 
@@ -269,6 +276,13 @@ func setMatchLabelsMatcher(constraint *unstructured.Unstructured, matcher rego.M
 func setNamespaceMatcher(constraint *unstructured.Unstructured, matcher rego.NamespaceMatchers) error {
 	if err := unstructured.SetNestedStringSlice(constraint.Object, matcher, "spec", "match", "namespaces"); err != nil {
 		return fmt.Errorf("set constraint namespace matchers: %w", err)
+	}
+	return nil
+}
+
+func setExcludedNamespacesMatcher(constraint *unstructured.Unstructured, matcher rego.ExcludedNamespacesMatchers) error {
+	if err := unstructured.SetNestedStringSlice(constraint.Object, matcher, "spec", "match", "excludedNamespaces"); err != nil {
+		return fmt.Errorf("set constraint excludedNamespaces matchers: %w", err)
 	}
 	return nil
 }

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -21,6 +21,7 @@ type Header struct {
 	Resources   string
 	MatchLabels string
 	Namespaces string
+	ExcludedNamespaces string
 	Anchor      string
 	Parameters  []rego.Parameter
 }
@@ -144,12 +145,15 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 
 		namespaces := matchers.NamespaceMatchers.String()
 
+		excludedNamespaces := matchers.ExcludedNamespacesMatchers.String()
+
 		header := Header{
 			Title:       documentTitle,
 			Description: policy.Description(),
 			Resources:   resources,
 			MatchLabels: matchLabels,
 			Namespaces: namespaces,
+			ExcludedNamespaces: excludedNamespaces,
 			Anchor:      anchor,
 			Parameters:  policy.Parameters(),
 		}

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -143,7 +143,7 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 		}
 		matchLabels := matchers.MatchLabelsMatcher.String()
 
-		namespaces := matchers.NamespaceMatchers.String()
+		namespaces := matchers.NamespacesMatchers.String()
 
 		excludedNamespaces := matchers.ExcludedNamespacesMatchers.String()
 

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -20,6 +20,7 @@ type Header struct {
 	Description string
 	Resources   string
 	MatchLabels string
+	Namespaces string
 	Anchor      string
 	Parameters  []rego.Parameter
 }
@@ -141,11 +142,14 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 		}
 		matchLabels := matchers.MatchLabelsMatcher.String()
 
+		namespaces := matchers.NamespaceMatchers.String()
+
 		header := Header{
 			Title:       documentTitle,
 			Description: policy.Description(),
 			Resources:   resources,
 			MatchLabels: matchLabels,
+			Namespaces: namespaces,
 			Anchor:      anchor,
 			Parameters:  policy.Parameters(),
 		}

--- a/internal/commands/document_template.go
+++ b/internal/commands/document_template.go
@@ -22,6 +22,11 @@ const docTemplate = `# Policies
 **MatchLabels:** {{ .Header.MatchLabels }}
 {{- end }}
 
+{{- if .Header.Namespaces }}
+
+**Namespaces:** {{ .Header.Namespaces }}
+{{- end }}
+
 {{- if .Header.Parameters }}
 
 **Parameters:**

--- a/internal/commands/document_template.go
+++ b/internal/commands/document_template.go
@@ -27,6 +27,11 @@ const docTemplate = `# Policies
 **Namespaces:** {{ .Header.Namespaces }}
 {{- end }}
 
+{{- if .Header.ExcludedNamespaces }}
+
+**Excluded Namespaces:** {{ .Header.ExcludedNamespaces }}
+{{- end }}
+
 {{- if .Header.Parameters }}
 
 **Parameters:**

--- a/internal/rego/matchers.go
+++ b/internal/rego/matchers.go
@@ -10,6 +10,7 @@ type Matchers struct {
 	KindMatchers       KindMatchers
 	MatchLabelsMatcher MatchLabelsMatcher
 	NamespaceMatchers NamespaceMatchers
+	ExcludedNamespacesMatchers ExcludedNamespacesMatchers
 }
 
 // KindMatchers is the slice of KindMatcher
@@ -53,6 +54,17 @@ func (n NamespaceMatchers) String() string {
 	return strings.TrimSpace(result)
 }
 
+type ExcludedNamespacesMatchers []string
+
+func (n ExcludedNamespacesMatchers) String() string {
+	var result string
+	for _, v := range n {
+		result += fmt.Sprintf("%s ", v)
+	}
+
+	return strings.TrimSpace(result)
+}
+
 // Matchers returns all of the matchers found in the rego file.
 func (r Rego) Matchers() (Matchers, error) {
 	var matchers Matchers
@@ -69,6 +81,10 @@ func (r Rego) Matchers() (Matchers, error) {
 		}
 		if strings.HasPrefix(comment, "@namespaces") {
 			matchers.NamespaceMatchers = getNamespacesMatchers(comment)
+		}
+
+		if strings.HasPrefix(comment, "@excludednamespaces") {
+			matchers.ExcludedNamespacesMatchers = getExcludedNamespacesMatchers(comment)
 		}
 	}
 
@@ -119,4 +135,16 @@ func getNamespacesMatchers(comment string) NamespaceMatchers {
 	}
 
 	return namespaceMatchers
+}
+
+func getExcludedNamespacesMatchers(comment string) ExcludedNamespacesMatchers {
+	var excludedNamespacesMatchers ExcludedNamespacesMatchers
+	matcherText := strings.TrimSpace(strings.SplitAfter(comment, "@excludednamespaces")[1])
+	excludedNamespacesMatcherGroups := strings.Split(matcherText, " ")
+
+	for _, matcher := range excludedNamespacesMatcherGroups {
+		excludedNamespacesMatchers = append(excludedNamespacesMatchers, matcher)
+	}
+
+	return excludedNamespacesMatchers
 }

--- a/internal/rego/matchers.go
+++ b/internal/rego/matchers.go
@@ -9,7 +9,7 @@ import (
 type Matchers struct {
 	KindMatchers       KindMatchers
 	MatchLabelsMatcher MatchLabelsMatcher
-	NamespaceMatchers NamespaceMatchers
+	NamespacesMatchers NamespacesMatchers
 	ExcludedNamespacesMatchers ExcludedNamespacesMatchers
 }
 
@@ -43,9 +43,9 @@ func (m MatchLabelsMatcher) String() string {
 	return strings.TrimSpace(result)
 }
 
-type NamespaceMatchers []string
+type NamespacesMatchers []string
 
-func (n NamespaceMatchers) String() string {
+func (n NamespacesMatchers) String() string {
 	var result string
 	for _, v := range n {
 		result += fmt.Sprintf("%s ", v)
@@ -80,7 +80,7 @@ func (r Rego) Matchers() (Matchers, error) {
 			}
 		}
 		if strings.HasPrefix(comment, "@namespaces") {
-			matchers.NamespaceMatchers = getNamespacesMatchers(comment)
+			matchers.NamespacesMatchers = getNamespacesMatchers(comment)
 		}
 
 		if strings.HasPrefix(comment, "@excludednamespaces") {
@@ -125,16 +125,16 @@ func getMatchLabelsMatcher(comment string) (MatchLabelsMatcher, error) {
 	return matcher, nil
 }
 
-func getNamespacesMatchers(comment string) NamespaceMatchers {
-	var namespaceMatchers NamespaceMatchers
+func getNamespacesMatchers(comment string) NamespacesMatchers {
+	var namespacesMatchers NamespacesMatchers
 	matcherText := strings.TrimSpace(strings.SplitAfter(comment, "@namespaces")[1])
-	namespaceMatcherGroups := strings.Split(matcherText, " ")
+	namespacesMatcherGroups := strings.Split(matcherText, " ")
 
-	for _, matcher := range namespaceMatcherGroups {
-		namespaceMatchers = append(namespaceMatchers, matcher)
+	for _, matcher := range namespacesMatcherGroups {
+		namespacesMatchers = append(namespacesMatchers, matcher)
 	}
 
-	return namespaceMatchers
+	return namespacesMatchers
 }
 
 func getExcludedNamespacesMatchers(comment string) ExcludedNamespacesMatchers {

--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -62,7 +62,7 @@ func TestGetNamespacesMatcher(t *testing.T) {
 		headerComments: comments,
 	}
 
-	expected := NamespaceMatchers{
+	expected := NamespacesMatchers{
 		"kube-system", "gatekeeper-system",
 	}
 
@@ -70,10 +70,10 @@ func TestGetNamespacesMatcher(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	actual := matchers.NamespaceMatchers
+	actual := matchers.NamespacesMatchers
 
 	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("Unexpected NamespaceMatchers. expected %v, actual %v.", expected, actual)
+		t.Errorf("Unexpected NamespacesMatchers. expected %v, actual %v.", expected, actual)
 	}
 }
 

--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -52,3 +52,27 @@ func TestGetMatchLabelsMatcher(t *testing.T) {
 		t.Errorf("Unexpected MatchLabelMatcher. expected %v, actual %v.", expected, actual)
 	}
 }
+
+func TestGetNamespacesMatcher(t *testing.T) {
+	comments := []string{
+		"@namespaces kube-system gatekeeper-system",
+	}
+
+	rego := Rego{
+		headerComments: comments,
+	}
+
+	expected := NamespaceMatchers{
+		"kube-system", "gatekeeper-system",
+	}
+
+	matchers, err := rego.Matchers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := matchers.NamespaceMatchers
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected NamespaceMatchers. expected %v, actual %v.", expected, actual)
+	}
+}

--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -76,3 +76,27 @@ func TestGetNamespacesMatcher(t *testing.T) {
 		t.Errorf("Unexpected NamespaceMatchers. expected %v, actual %v.", expected, actual)
 	}
 }
+
+func TestGetExcludedNamespacesMatcher(t *testing.T) {
+	comments := []string{
+		"@excludednamespaces kube-system gatekeeper-system",
+	}
+
+	rego := Rego{
+		headerComments: comments,
+	}
+
+	expected := ExcludedNamespacesMatchers{
+		"kube-system", "gatekeeper-system",
+	}
+
+	matchers, err := rego.Matchers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := matchers.ExcludedNamespacesMatchers
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected ExcludedNamespacesMatchers. expected %v, actual %v.", expected, actual)
+	}
+}


### PR DESCRIPTION
#106 

```go
# @namespaces kube-system gatekeeper-system
package foo

import data.lib.core
...
```

↓

```yaml
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: Foo
metadata:
  name: foo
spec:
  match:
    namespaces:
      - kube-system
      - gatekeeper-system
```

---

```go
# @ excludednamespaces kube-system gatekeeper-system
package foo

import data.lib.core
...
```

↓

```yaml
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: Foo
metadata:
  name: foo
spec:
  match:
    excludedNamespaces:
      - kube-system
      - gatekeeper-system
```