### PR TITLE
Change permission to create files

### DIFF
--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -87,7 +87,7 @@ func runCreateCommand(path string) error {
 			return fmt.Errorf("marshal constrainttemplate: %w", err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(outputDir, templateFileName), constraintTemplateBytes, os.ModePerm); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(outputDir, templateFileName), constraintTemplateBytes, 0644); err != nil {
 			return fmt.Errorf("writing template: %w", err)
 		}
 
@@ -114,7 +114,7 @@ func runCreateCommand(path string) error {
 			return fmt.Errorf("marshal constraint: %w", err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(outputDir, constraintFileName), constraintBytes, os.ModePerm); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(outputDir, constraintFileName), constraintBytes, 0644); err != nil {
 			return fmt.Errorf("writing constraint: %w", err)
 		}
 	}

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -84,7 +84,7 @@ func runDocCommand(path string) error {
 		return fmt.Errorf("parsing template: %w", err)
 	}
 
-	f, err := os.OpenFile(viper.GetString("output"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	f, err := os.OpenFile(viper.GetString("output"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("opening file for writing: %w", err)
 	}


### PR DESCRIPTION
Hi there!

The template.yaml, constraint.yaml and policies.md generated by konstraint are given execute bits.

```
$ konstraint create .
$ ls -l policy/test
total 12
-rwxr-xr-x 1 hnts hnts  188 Mar  2 21:10 constraint.yaml*
-rw-r--r-- 1 hnts hnts  263 Mar  1 23:26 src.rego
-rwxr-xr-x 1 hnts hnts 2526 Mar  2 21:10 template.yaml*
```

I changed the permissions granted to those files!