### PR TITLE
Update pipelines to use GHCR

### DIFF
--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -33,9 +33,7 @@ jobs:
       run: echo TAG_NAME=$(echo ${GITHUB_REF} | rev | cut -d"/" -f1 | rev) >> $GITHUB_ENV
 
     - name: docker login
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: echo "${GITHUB_TOKEN}" | docker login https://${DOCKER_REPO} -u ${GITHUB_ACTOR} --password-stdin
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
     - name: docker build
       run: make docker-build version=${TAG_NAME}

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,60 @@
-IMAGE := docker.pkg.github.com/plexsystems/konstraint
+## The repository where the container image will be pushed to.
+IMAGE := ghcr.io/plexsystems/konstraint
+
+#
+##@ Development
+#
 
 .PHONY: build
-build:
+build: ## Builds the binary. It will be placed into the build directory.
 	go build -o build/konstraint
 
 .PHONY: test
-test:
+test: ## Runs the unit tests.
 	go test -v ./... -count=1
 
 .PHONY: acceptance
-acceptance: build
+acceptance: build ## Runs the acceptance tests.
 	bats acceptance.bats
 
 .PHONY: policy
-policy:
+policy: ## Runs the policy tests.
 	conftest verify -p examples
 
 .PHONY: update-static
-update-static: build
+update-static: build ## Updates the static assets in the repository.
 	./build/konstraint create examples
 	./build/konstraint create test/create --output test/create
 	./build/konstraint doc examples --output examples/policies.md
 	./build/konstraint doc examples --output test/doc/expected.md
 
-# A version is required when creating a release (make release version=0.6.0)
-# Running this command without a version variable set will result in an error.
+#
+##@ Releases
+#
+
+.PHONY: docker-build
+docker-build: ## Builds the docker image. Can optionally pass in a version.
+ifeq ($(version),)
+	docker build -t konstraint:latest .
+else
+	docker build -t konstraint:latest -t konstraint:$(version) --build-arg KONSTRAINT_VER=$(version) .
+endif
+
+.PHONY: docker-push
+docker-push: ## Pushes the docker image to the container registry.
+	@test $(version)
+	docker tag konstraint:latest $(IMAGE):$(version)
+	docker tag konstraint:latest $(IMAGE):latest
+	docker push $(IMAGE):$(version)
+	docker push $(IMAGE):latest
+
 .PHONY: release
-release:
+release: ## Builds the binaries for each OS and creates the checksums.
 	@test $(version)
 	GOOS=darwin GOARCH=amd64 go build -o build/konstraint-darwin-amd64 -ldflags="-X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
 	GOOS=windows GOARCH=amd64 go build -o build/konstraint-windows-amd64.exe -ldflags="-X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
 	GOOS=linux GOARCH=amd64 go build -o build/konstraint-linux-amd64 -ldflags="-X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
 	docker run --rm -v $(shell pwd):/konstraint alpine:3 /bin/ash -c 'cd /konstraint/build && sha256sum konstraint-* > checksums.txt'
 
-.PHONY: docker-build
-docker-build:
-ifeq ($(version),) # this can't be indented because makefiles are picky
-	docker build -t konstraint:latest .
-else
-	docker build -t konstraint:latest -t konstraint:$(version) --build-arg KONSTRAINT_VER=$(version) .
-endif
-
-# The version and the docker repository are required to use the docker-push target
-.PHONY: docker-push
-docker-push:
-	@test $(DOCKER_REPO)
-	@test $(version)
-	docker tag konstraint:latest $(IMAGE):$(version)
-	docker tag konstraint:latest $(IMAGE):latest
-	docker push $(IMAGE):$(version)
-	docker push $(IMAGE):latest
+help:
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
PR for visibility. Tested docker login with GHCR in a test PR and it seemed to auth correctly. Would like to merge this in and try pushing out 0.13 for the new `--no-rego` flag and to verify the pipeline works.