### PR TITLE
Update approaches for releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM golang:1.16.3-alpine AS build
+ARG KONSTRAINT_VER
+
 WORKDIR /go/src/github.com/plexsystems/konstraint
+
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
+
 COPY main.go .
 COPY internal/ internal
-ARG KONSTRAINT_VER
+
 RUN go build -o /konstraint -ldflags="-X 'github.com/plexsystems/konstraint/internal/commands.version=${KONSTRAINT_VER}'"
 
 FROM alpine:3.13.5

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Konstraint is a CLI tool to assist with the creation and management of templates
 ## Installation
 
 ```text
-GO111MODULE=on go get github.com/plexsystems/konstraint
+go install github.com/plexsystems/konstraint@latest
 ```
 
-Binaries are also available on the [releases](https://github.com/plexsystems/konstraint/releases) page.
+A docker image is also provided for each release:
+
+```text
+docker run -v $PWD:/konstraint ghcr.io/plexsystems/konstraint create /konstraint/examples
+```
 
 ## Usage
 

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -16,8 +17,10 @@ func NewDefaultCommand() *cobra.Command {
 		Use:     path.Base(os.Args[0]),
 		Short:   "Konstraint",
 		Long:    "A tool to create and manage Gatekeeper CRDs from Rego",
-		Version: version,
+		Version: fmt.Sprintf("Version: %s\n", version),
 	}
+
+	cmd.SetVersionTemplate(`{{.Version}}`)
 
 	cmd.AddCommand(newCreateCommand())
 	cmd.AddCommand(newDocCommand())


### PR DESCRIPTION
- Update the README to use `go install` rather than `GO111MODULES` now that modules are more or less on by default and install is the preferred method.

- Showcase that images are now available at `ghcr.io/plexsystems/konstraint`

- Make the `version` parameter non-blank so that the `--version` flag always works. Without a version specified, the `version` variable is blank which causes cobra to throw an error: `Error: unknown flag: --version`