### PR TITLE
Add logging to Konstraint output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20210317225149-4f80ac172ddf
 	github.com/open-policy-agent/opa v0.29.4
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	k8s.io/apiextensions-apiserver v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -702,6 +702,7 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -73,7 +73,6 @@ func runCreateCommand(path string) error {
 			"name": violation.Kind(),
 			"src":  violation.Path(),
 		})
-		logger.Debug("starting processing policy")
 
 		templateFileName := "template.yaml"
 		constraintFileName := "constraint.yaml"
@@ -88,14 +87,12 @@ func runCreateCommand(path string) error {
 			return fmt.Errorf("create output dir: %w", err)
 		}
 
-		logger.Debug("generating constrainttemplate")
 		constraintTemplate := getConstraintTemplate(violation)
 		constraintTemplateBytes, err := yaml.Marshal(&constraintTemplate)
 		if err != nil {
 			return fmt.Errorf("marshal constrainttemplate: %w", err)
 		}
 
-		logger.WithField("out_file", filepath.Join(outputDir, templateFileName)).Debug("writing constrainttemplate")
 		if err := ioutil.WriteFile(filepath.Join(outputDir, templateFileName), constraintTemplateBytes, 0644); err != nil {
 			return fmt.Errorf("writing template: %w", err)
 		}
@@ -111,7 +108,6 @@ func runCreateCommand(path string) error {
 			continue
 		}
 
-		logger.Debug("generating constraint")
 		constraint, err := getConstraint(violation)
 		if err != nil {
 			return fmt.Errorf("get constraint: %w", err)
@@ -122,7 +118,6 @@ func runCreateCommand(path string) error {
 			return fmt.Errorf("marshal constraint: %w", err)
 		}
 
-		logger.WithField("out_file", filepath.Join(outputDir, constraintFileName)).Debug("writing constraint")
 		if err := ioutil.WriteFile(filepath.Join(outputDir, constraintFileName), constraintBytes, 0644); err != nil {
 			return fmt.Errorf("writing constraint: %w", err)
 		}

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // version is set during the build process.
@@ -18,6 +20,27 @@ func NewDefaultCommand() *cobra.Command {
 		Short:   "Konstraint",
 		Long:    "A tool to create and manage Gatekeeper CRDs from Rego",
 		Version: fmt.Sprintf("Version: %s\n", version),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			switch viper.GetString("log-level") {
+			case "debug":
+				log.SetLevel(log.DebugLevel)
+			case "info":
+				log.SetLevel(log.InfoLevel)
+			case "warn":
+				log.SetLevel(log.WarnLevel)
+			case "error":
+				log.SetLevel(log.ErrorLevel)
+			default:
+				return fmt.Errorf("log-level is invalid: %s", viper.GetString("log-level"))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().String("log-level", "info", "Log level (debug, info, warn, error)")
+	if err := viper.BindPFlag("log-level", cmd.PersistentFlags().Lookup("log-level")); err != nil {
+		log.Fatalf("bind log-level flag: %w", err)
 	}
 
 	cmd.SetVersionTemplate(`{{.Version}}`)

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -40,7 +40,7 @@ func NewDefaultCommand() *cobra.Command {
 
 	cmd.PersistentFlags().String("log-level", "info", "Log level (debug, info, warn, error)")
 	if err := viper.BindPFlag("log-level", cmd.PersistentFlags().Lookup("log-level")); err != nil {
-		log.Fatalf("bind log-level flag: %w", err)
+		log.Fatalf("bind log-level flag: %v", err)
 	}
 
 	cmd.SetVersionTemplate(`{{.Version}}`)

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -5,9 +5,7 @@ import (
 	"os"
 	"path"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // version is set during the build process.
@@ -20,27 +18,6 @@ func NewDefaultCommand() *cobra.Command {
 		Short:   "Konstraint",
 		Long:    "A tool to create and manage Gatekeeper CRDs from Rego",
 		Version: fmt.Sprintf("Version: %s\n", version),
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			switch viper.GetString("log-level") {
-			case "debug":
-				log.SetLevel(log.DebugLevel)
-			case "info":
-				log.SetLevel(log.InfoLevel)
-			case "warn":
-				log.SetLevel(log.WarnLevel)
-			case "error":
-				log.SetLevel(log.ErrorLevel)
-			default:
-				return fmt.Errorf("log-level is invalid: %s", viper.GetString("log-level"))
-			}
-
-			return nil
-		},
-	}
-
-	cmd.PersistentFlags().String("log-level", "info", "Log level (debug, info, warn, error)")
-	if err := viper.BindPFlag("log-level", cmd.PersistentFlags().Lookup("log-level")); err != nil {
-		log.Fatalf("bind log-level flag: %v", err)
 	}
 
 	cmd.SetVersionTemplate(`{{.Version}}`)

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -80,7 +80,6 @@ func runDocCommand(path string) error {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	log.Debug("generating documentation")
 	docs, err := getDocumentation(path, outputDirectory)
 	if err != nil {
 		return fmt.Errorf("get documentation: %w", err)
@@ -91,7 +90,6 @@ func runDocCommand(path string) error {
 		return fmt.Errorf("parsing template: %w", err)
 	}
 
-	log.WithField("out_file", viper.GetString("output")).Debug("writing documentation")
 	f, err := os.OpenFile(viper.GetString("output"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("opening file for writing: %w", err)
@@ -126,7 +124,6 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 			"name": policy.Kind(),
 			"src":  policy.Path(),
 		})
-		logger.Debug("starting processing policy")
 
 		if policy.Title() == "" {
 			logger.Warn("no title set, skipping documentation generation")

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/plexsystems/konstraint/internal/rego"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -79,6 +80,7 @@ func runDocCommand(path string) error {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
+	log.Debug("generating documentation")
 	docs, err := getDocumentation(path, outputDirectory)
 	if err != nil {
 		return fmt.Errorf("get documentation: %w", err)
@@ -89,6 +91,7 @@ func runDocCommand(path string) error {
 		return fmt.Errorf("parsing template: %w", err)
 	}
 
+	log.WithField("out_file", viper.GetString("output")).Debug("writing documentation")
 	f, err := os.OpenFile(viper.GetString("output"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("opening file for writing: %w", err)
@@ -97,6 +100,12 @@ func runDocCommand(path string) error {
 	if err := t.Execute(f, docs); err != nil {
 		return fmt.Errorf("executing template: %w", err)
 	}
+
+	var numPolicies int
+	for _, policies := range docs {
+		numPolicies += len(policies)
+	}
+	log.WithField("num_policies", numPolicies).Info("completed successfully")
 
 	return nil
 }
@@ -107,9 +116,20 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 		return nil, fmt.Errorf("get all severities: %w", err)
 	}
 
+	if viper.GetBool("no-rego") {
+		log.Info("no-rego flag is set. policy source will not be included in the documentation")
+	}
+
 	documents := make(map[rego.Severity][]Document)
 	for _, policy := range policies {
+		logger := log.WithFields(log.Fields{
+			"name": policy.Kind(),
+			"src":  policy.Path(),
+		})
+		logger.Debug("starting processing policy")
+
 		if policy.Title() == "" {
+			logger.Warn("no title set, skipping documentation generation")
 			continue
 		}
 
@@ -150,6 +170,7 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 		}
 		resources := matchers.KindMatchers.String()
 		if resources == "" {
+			logger.Warn("no kind matchers set, this can lead to poor policy performance")
 			resources = "Any Resource"
 		}
 		matchLabels := matchers.MatchLabelsMatcher.String()


### PR DESCRIPTION
This adds logging output to Konstraint as it processes policies. Debug level is used only for more verbose output, Info is used when Konstraint takes non-default paths due to user configuration as well as status updates for major steps, and Warn is used when Konstraint takes non-default paths due to implicit configurations that the user may not be aware of.

Fixes #170

Examples:

```
$ ./build/konstraint --log-level info doc examples -o examples/policies.md --no-rego
INFO[0000] no-rego flag is set. policy source will not be included in the documentation 
WARN[0000] no kind matchers set, this can lead to poor policy performance  name=RequiredLabels src=examples/required-labels/src.rego
INFO[0000] completed successfully                        num_policies=23
```

```
$ ./build/konstraint create examples                  
WARN[0000] skipping constraint generation due to use of parameters  name=RequiredLabels src=examples/required-labels/src.rego
INFO[0000] completed successfully                        num_policies=20
```