### PR TITLE
Improve release target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ docker-push: ## Pushes the docker image to the container registry.
 .PHONY: release
 release: ## Builds the binaries for each OS and creates the checksums.
 	@test $(version)
-	GOOS=darwin GOARCH=amd64 go build -o build/konstraint-darwin-amd64 -ldflags="-X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
-	GOOS=windows GOARCH=amd64 go build -o build/konstraint-windows-amd64.exe -ldflags="-X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
-	GOOS=linux GOARCH=amd64 go build -o build/konstraint-linux-amd64 -ldflags="-X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
-	docker run --rm -v $(shell pwd):/konstraint alpine:3 /bin/ash -c 'cd /konstraint/build && sha256sum konstraint-* > checksums.txt'
+	GOOS=darwin GOARCH=amd64 go build -o build/konstraint-darwin-amd64 -ldflags="-s -w -X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
+	GOOS=windows GOARCH=amd64 go build -o build/konstraint-windows-amd64.exe -ldflags="-s -w -X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
+	GOOS=linux GOARCH=amd64 go build -o build/konstraint-linux-amd64 -ldflags="-s -w -X 'github.com/plexsystems/konstraint/internal/commands.version=$(version)'"
+	docker run --user $(shell id -u):$(shell id -g) --rm -v $(shell pwd):/konstraint alpine:3 /bin/ash -c 'cd /konstraint/build && sha256sum konstraint-* > checksums.txt'
 
 help:
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
- Reduce size of Konstraint binaries (by removing debug symbols)
- Run checksum generation as the current user, preserving expected permissions