### PR TITLE
Do not parse imports on documentation generation

### DIFF
--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -109,7 +109,7 @@ func runDocCommand(path string) error {
 }
 
 func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]Document, error) {
-	policies, err := rego.GetAllSeverities(path)
+	policies, err := rego.GetAllSeveritiesWithoutImports(path)
 	if err != nil {
 		return nil, fmt.Errorf("get all severities: %w", err)
 	}


### PR DESCRIPTION
This allows for documentation generation for policies not related
to Gatekeeper.

Fixes #185.

Signed-off-by: James Alseth <james@jalseth.me>