### PR TITLE
 Add `--include-comments` flag for the `doc` command

### DIFF
--- a/docs/cli/konstraint_doc.md
+++ b/docs/cli/konstraint_doc.md
@@ -22,10 +22,11 @@ Set the URL where the policies are hosted at
 ### Options
 
 ```
-  -h, --help            help for doc
-      --no-rego         Do not include the Rego in the policy documentation
-  -o, --output string   Output location (including filename) for the policy documentation (default "policies.md")
-      --url string      The URL where the policy files are hosted at (e.g. https://github.com/policies)
+  -h, --help               help for doc
+      --include-comments   Include comments from the rego source in the documentation
+      --no-rego            Do not include the Rego in the policy documentation
+  -o, --output string      Output location (including filename) for the policy documentation (default "policies.md")
+      --url string         The URL where the policy files are hosted at (e.g. https://github.com/policies)
 ```
 
 ### SEE ALSO

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,10 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -556,12 +558,15 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -58,6 +58,10 @@ Set the URL where the policies are hosted at
 				return fmt.Errorf("bind no-rego flag: %w", err)
 			}
 
+			if err := viper.BindPFlag("include-comments", cmd.Flags().Lookup("include-comments")); err != nil {
+				return fmt.Errorf("bind include-comments flag: %w", err)
+			}
+
 			path := "."
 			if len(args) > 0 {
 				path = args[0]
@@ -70,6 +74,7 @@ Set the URL where the policies are hosted at
 	cmd.Flags().StringP("output", "o", "policies.md", "Output location (including filename) for the policy documentation")
 	cmd.Flags().String("url", "", "The URL where the policy files are hosted at (e.g. https://github.com/policies)")
 	cmd.Flags().Bool("no-rego", false, "Do not include the Rego in the policy documentation")
+	cmd.Flags().Bool("include-comments", false, "Include comments from the rego source in the documentation")
 
 	return &cmd
 }
@@ -181,7 +186,12 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 			Parameters:  policy.Parameters(),
 		}
 
-		rego := policy.Source()
+		var rego string
+		if viper.GetBool("include-comments") {
+			rego = policy.FullSource()
+		} else {
+			rego = policy.Source()
+		}
 		if viper.GetBool("no-rego") {
 			rego = ""
 		}

--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -229,6 +229,27 @@ func (r Rego) Source() string {
 	return removeComments(r.raw)
 }
 
+// FullSource returns the original source code inside
+// of the rego file including comments except the header
+func (r Rego) FullSource() string {
+	withoutHeader := removeHeaderComments(r.raw)
+
+	return strings.Trim(withoutHeader, "\n\t ")
+}
+
+func removeHeaderComments(input string) string {
+	var result string
+	split := strings.Split(input, "\n")
+	for i, line := range split {
+		if !strings.HasPrefix(line, "#") {
+			result = strings.Join(split[i:len(split)-1], "\n")
+			break
+		}
+	}
+
+	return result
+}
+
 // Dependencies returns all of the source for the rego files that this
 // rego file depends on.
 func (r Rego) Dependencies() []string {


### PR DESCRIPTION
Users may want to include the source comments in the generated
documentation as it can help explain reasoning for the policy
such as exceptions that are added.