### PR TITLE
Fix @parameter check

### DIFF
--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -394,7 +394,7 @@ func getBodyParamNames(rules []*ast.Rule) []string {
 func getHeaderParams(comments []string) ([]Parameter, error) {
 	var parameters []Parameter
 	for _, comment := range comments {
-		if !commentStartsWith(comment, "@parameter") {
+		if !commentStartsWith(comment, "@parameter ") {
 			continue
 		}
 


### PR DESCRIPTION
Hi mentainers, thank you for the nice plugin!

I found some error and fixed it.

## reproduce

```rego
# @parameters labels array string
# ↑ @parameter is correct
```

### expected

```
$ konstraint create .
Error: get violations: parse directory: missing @parameter tags for parameters [repositories] found in the policy: example/src.rego
Usage:
  konstraint create <dir> [flags]

Examples:
Create constraints in the same directories as the policies
        konstraint create examples

Save the constraints in a specific directory
        konstraint create examples --output generated-constraints

Create constraints with the Gatekeeper enforcement action set to dryrun
        konstraint create examples --dryrun

Flags:
  -d, --dryrun             Sets the enforcement action of the constraints to dryrun, overriding the @enforcement tag
  -h, --help               help for create
  -o, --output string      Specify an output directory for the Gatekeeper resources
      --skip-constraints   Skip generation of constraints
```

### actual

```
$ konstraint create .
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/plexsystems/konstraint/internal/rego.getHeaderParams({0xc000632040, 0x3, 0x26})
        /Users/ryo.kitagawa/go/src/github.com/plexsystems/konstraint/internal/rego/rego.go:402 +0x469
github.com/plexsystems/konstraint/internal/rego.parseDirectory({0x7ffeefbfed02, 0x1}, 0x1)
        /Users/ryo.kitagawa/go/src/github.com/plexsystems/konstraint/internal/rego/rego.go:329 +0x7c8
github.com/plexsystems/konstraint/internal/rego.GetViolations({0x7ffeefbfed02, 0xc001135b80})
        /Users/ryo.kitagawa/go/src/github.com/plexsystems/konstraint/internal/rego/rego.go:84 +0x3b
github.com/plexsystems/konstraint/internal/commands.runCreateCommand({0x7ffeefbfed02, 0x1710a8d})
        /Users/ryo.kitagawa/go/src/github.com/plexsystems/konstraint/internal/commands/create.go:66 +0x36
github.com/plexsystems/konstraint/internal/commands.newCreateCommand.func1(0xc0001f8280, {0xc00018eeb0, 0x1, 0x1})
        /Users/ryo.kitagawa/go/src/github.com/plexsystems/konstraint/internal/commands/create.go:54 +0x239
github.com/spf13/cobra.(*Command).execute(0xc0001f8280, {0xc00018ee80, 0x1, 0x1})
        /Users/ryo.kitagawa/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001f8000)
        /Users/ryo.kitagawa/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/ryo.kitagawa/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
        /Users/ryo.kitagawa/go/src/github.com/plexsystems/konstraint/main.go:10 +0x1e
```