### PR TITLE
Add support for @matchExpression label selector

### DIFF
--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -52,3 +52,63 @@ func TestGetMatchLabelsMatcher(t *testing.T) {
 		t.Errorf("Unexpected MatchLabelMatcher. expected %v, actual %v.", expected, actual)
 	}
 }
+
+func TestGetMatchExpressionsMatcher(t *testing.T) {
+	testCases := []struct {
+		name      string
+		comments  []string
+		expected  []MatchExpressionMatcher
+		wantError bool
+	}{
+		{
+			name: "Empty",
+		},
+		{
+			name:     "Single",
+			comments: []string{"@matchExpression foo In bar,baz"},
+			expected: []MatchExpressionMatcher{
+				{Key: "foo", Operator: "In", Values: []string{"bar", "baz"}},
+			},
+		},
+		{
+			name: "DoubleWithUnrelated",
+			comments: []string{
+				"@matchExpression foo In bar,baz",
+				"@matchExpression doggos Exists",
+				"unrelated comment",
+			},
+			expected: []MatchExpressionMatcher{
+				{Key: "foo", Operator: "In", Values: []string{"bar", "baz"}},
+				{Key: "doggos", Operator: "Exists"},
+			},
+		},
+		{
+			name: "TooFewParams",
+			comments: []string{
+				"@matchExpression foo",
+			},
+			wantError: true,
+		},
+		{
+			name: "TooManyParams",
+			comments: []string{
+				"@matchExpression foo In bar baz",
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rego := Rego{headerComments: tc.comments}
+			matchers, err := rego.Matchers()
+			if (err != nil && !tc.wantError) || (err == nil && tc.wantError) {
+				t.Errorf("Unexpected error state, have %v want %v", !tc.wantError, tc.wantError)
+			}
+			actual := matchers.MatchExpressionsMatcher
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("Unexpected MatchExpressionsMatcher, have %v want %v", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/test/constraint_Test.yaml
+++ b/test/constraint_Test.yaml
@@ -13,3 +13,12 @@ spec:
       - Deployment
       - StatefulSet
       - Pod
+    labelSelector:
+      matchExpressions:
+      - key: foo
+        operator: In
+        values:
+        - bar
+        - baz
+      - key: doggos
+        operator: Exists

--- a/test/src.rego
+++ b/test/src.rego
@@ -3,6 +3,8 @@
 # The description
 #
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
+# @matchExpression foo In bar,baz
+# @matchExpression doggos Exists
 package test
 
 import future.keywords


### PR DESCRIPTION
This allows for greater flexibility when matching constraints based on
labels by extending exact matches to also allow In, NotIn, Exists, and
DoesNotExist operators [1].

[1] https://open-policy-agent.github.io/gatekeeper/website/docs/howto/#the-match-field

Signed-off-by: James Alseth <james@jalseth.me>

---

Fixes #237 