### PR TITLE
Add @namespaces and @excludedNamespaces matchers

### DIFF
--- a/docs/cli/konstraint_create.md
+++ b/docs/cli/konstraint_create.md
@@ -22,11 +22,12 @@ Create constraints with the Gatekeeper enforcement action set to dryrun
 ### Options
 
 ```
-  -d, --dryrun                Sets the enforcement action of the constraints to dryrun, overriding the @enforcement tag
-  -h, --help                  help for create
-  -o, --output string         Specify an output directory for the Gatekeeper resources
-      --partial-constriants   Generate partial Constraints for policies with parameters
-      --skip-constraints      Skip generation of constraints
+      --constraint-template-version string   Set the version of ConstraintTemplates (default "v1beta1")
+  -d, --dryrun                               Sets the enforcement action of the constraints to dryrun, overriding the @enforcement tag
+  -h, --help                                 help for create
+  -o, --output string                        Specify an output directory for the Gatekeeper resources
+      --partial-constraints                  Generate partial Constraints for policies with parameters
+      --skip-constraints                     Skip generation of constraints
 ```
 
 ### SEE ALSO

--- a/docs/cli/konstraint_doc.md
+++ b/docs/cli/konstraint_doc.md
@@ -14,7 +14,7 @@ Generate the documentation
 
 Save the documentation to a specific directory
 	konstraint doc --output docs/policies.md
-	
+
 Set the URL where the policies are hosted at
 	konstraint doc --url https://github.com/plexsystems/konstraint
 ```

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,10 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -536,8 +538,10 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -294,6 +294,18 @@ func getConstraint(violation rego.Rego) (unstructured.Unstructured, error) {
 		}
 	}
 
+	if len(matchers.NamespaceMatcher) > 0 {
+		if err := setNestedStringSlice(&constraint, matchers.NamespaceMatcher, "spec", "match", "namespaces"); err != nil {
+			return unstructured.Unstructured{}, fmt.Errorf("set namespace matcher: %w", err)
+		}
+	}
+
+	if len(matchers.ExcludedNamespaceMatcher) > 0 {
+		if err := setNestedStringSlice(&constraint, matchers.ExcludedNamespaceMatcher, "spec", "match", "excludedNamespaces"); err != nil {
+			return unstructured.Unstructured{}, fmt.Errorf("set namespace matcher: %w", err)
+		}
+	}
+
 	if len(violation.Parameters()) > 0 && viper.GetBool("partial-constraints") {
 		if err := addParametersToConstraint(&constraint, violation.Parameters()); err != nil {
 			return unstructured.Unstructured{}, fmt.Errorf("add parameters %v to constraint: %w", violation.Parameters(), err)
@@ -376,6 +388,14 @@ func setMatchExpressionsMatcher(constraint *unstructured.Unstructured, matcher [
 		return err
 	}
 	return unstructured.SetNestedSlice(constraint.Object, unmarshalled, "spec", "match", "labelSelector", "matchExpressions")
+}
+
+func setNestedStringSlice(constraint *unstructured.Unstructured, slice []string, path ...string) error {
+	var values []interface{}
+	for _, s := range slice {
+		values = append(values, interface{}(s))
+	}
+	return unstructured.SetNestedSlice(constraint.Object, values, path...)
 }
 
 func isValidEnforcementAction(action string) bool {

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -41,7 +41,7 @@ func newDocCommand() *cobra.Command {
 
 Save the documentation to a specific directory
 	konstraint doc --output docs/policies.md
-	
+
 Set the URL where the policies are hosted at
 	konstraint doc --url https://github.com/plexsystems/konstraint`,
 
@@ -95,7 +95,7 @@ func runDocCommand(path string) error {
 		return fmt.Errorf("parsing template: %w", err)
 	}
 
-	f, err := os.OpenFile(viper.GetString("output"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(viper.GetString("output"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("opening file for writing: %w", err)
 	}

--- a/internal/rego/matchers_test.go
+++ b/internal/rego/matchers_test.go
@@ -112,3 +112,42 @@ func TestGetMatchExpressionsMatcher(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStringListMatcher(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		tag       string
+		comment   string
+		expected  []string
+		wantError bool
+	}{
+		{
+			desc:      "InvalidTag",
+			wantError: true, // will error without a match on the tag
+		},
+		{
+			desc:      "NoValuesSupplied",
+			tag:       "@foo",
+			comment:   "@foo     ",
+			wantError: true,
+		},
+		{
+			desc:     "Valid",
+			tag:      "@foo",
+			comment:  "@foo bar baz",
+			expected: []string{"bar", "baz"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			actual, err := getStringListMatcher(tc.tag, tc.comment)
+			if (err != nil && !tc.wantError) || (err == nil && tc.wantError) {
+				t.Errorf("Unexpected error state, have %v want %v", !tc.wantError, tc.wantError)
+			}
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("Unexpected values, have %v want %v", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/test/constraint_Test.yaml
+++ b/test/constraint_Test.yaml
@@ -4,6 +4,9 @@ metadata:
   name: test
 spec:
   match:
+    excludedNamespaces:
+    - kube-system
+    - gatekeeper-system
     kinds:
     - apiGroups:
       - apps
@@ -22,3 +25,7 @@ spec:
         - baz
       - key: doggos
         operator: Exists
+    namespaces:
+    - dev
+    - stage
+    - prod

--- a/test/src.rego
+++ b/test/src.rego
@@ -5,6 +5,8 @@
 # @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
 # @matchExpression foo In bar,baz
 # @matchExpression doggos Exists
+# @namespaces dev stage prod
+# @excludedNamespaces kube-system gatekeeper-system
 package test
 
 import future.keywords


### PR DESCRIPTION
Adds tags to enable the use of the `namespaces` and `excludedNamespaces`
matchers supported by Gatekeeper.

https://open-policy-agent.github.io/gatekeeper/website/docs/howto/#the-match-field

Signed-off-by: James Alseth <james@jalseth.me>

---

Fixes #244