### PR TITLE
Include test/ folder in e2e tests

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -131,6 +131,7 @@ jobs:
         run: |
           chmod +x ./konstraint
           ./konstraint create -o e2e-resources examples
+          ./konstraint create -o e2e-resources test
 
       - name: create kind cluster
         run: kind create cluster

--- a/test/src.rego
+++ b/test/src.rego
@@ -9,7 +9,6 @@
 # @excludedNamespaces kube-system gatekeeper-system
 package test
 
-import future.keywords
 import data.lib.libraryA
 
 policyID := "P123456"

--- a/test/template_Test.yaml
+++ b/test/template_Test.yaml
@@ -18,7 +18,6 @@ spec:
     rego: |-
       package test
 
-      import future.keywords
       import data.lib.libraryA
 
       policyID := "P123456"


### PR DESCRIPTION
We should make sure our acceptance test resources are valid Gatekeeper
configs.

Signed-off-by: James Alseth <james@jalseth.me>