### PR TITLE
Fix violation rule return format in test policy

### DIFF
--- a/test/src.rego
+++ b/test/src.rego
@@ -13,6 +13,6 @@ import data.lib.libraryA
 
 policyID := "P123456"
 
-violation["msg"] {
+violation[{"msg": "msg"}] {
     true # some comment with a trailing space 
 }

--- a/test/template_Test.yaml
+++ b/test/template_Test.yaml
@@ -22,7 +22,7 @@ spec:
 
       policyID := "P123456"
 
-      violation["msg"] {
+      violation[{"msg": "msg"}] {
           true # some comment with a trailing space
       }
     target: admission.k8s.gatekeeper.sh


### PR DESCRIPTION
Gatekeeper v3.8.0 and later now require '{msg: "message"}' return values for
deny rules.

Signed-off-by: James Alseth <james@jalseth.me>