### PR TITLE
Run e2e tests weekly

### DIFF
--- a/.github/workflows/cron_e2e.yaml
+++ b/.github/workflows/cron_e2e.yaml
@@ -2,7 +2,7 @@ name: E2E Weekly
 on:
   workflow_dispatch: # Allow manual runs
   schedule:
-    cron: '35 16 * * 1' # 16:35 UTC, weekly on Monday
+    - cron: '35 16 * * 1' # 16:35 UTC, weekly on Monday
 
 jobs:
   build:


### PR DESCRIPTION
This will notify us if upstream changes break Konstraint even when we don't make code changes.

Signed-off-by: James Alseth <james@jalseth.me>