### PR TITLE
Check parent as well as exact match when resolving imports

### DIFF
--- a/examples/pod-deny-host-alias/src.rego
+++ b/examples/pod-deny-host-alias/src.rego
@@ -18,7 +18,9 @@
 #       - StatefulSet
 package pod_deny_host_alias
 
-import data.lib.core
+import data.lib.core.format_with_id
+import data.lib.core.kind
+import data.lib.core.name
 import data.lib.pods
 
 policyID := "P1004"
@@ -26,7 +28,7 @@ policyID := "P1004"
 violation[msg] {
 	pod_host_alias
 
-	msg := core.format_with_id(sprintf("%s/%s: Pod has hostAliases defined", [core.kind, core.name]), policyID)
+	msg := format_with_id(sprintf("%s/%s: Pod has hostAliases defined", [kind, name]), policyID)
 }
 
 pod_host_alias {

--- a/examples/pod-deny-host-alias/template.yaml
+++ b/examples/pod-deny-host-alias/template.yaml
@@ -102,7 +102,9 @@ spec:
     rego: |-
       package pod_deny_host_alias
 
-      import data.lib.core
+      import data.lib.core.format_with_id
+      import data.lib.core.kind
+      import data.lib.core.name
       import data.lib.pods
 
       policyID := "P1004"
@@ -110,7 +112,7 @@ spec:
       violation[msg] {
         pod_host_alias
 
-        msg := core.format_with_id(sprintf("%s/%s: Pod has hostAliases defined", [core.kind, core.name]), policyID)
+        msg := format_with_id(sprintf("%s/%s: Pod has hostAliases defined", [kind, name]), policyID)
       }
 
       pod_host_alias {

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -191,7 +191,9 @@ Pods that can change aliases in the host's /etc/hosts file can redirect traffic 
 ```rego
 package pod_deny_host_alias
 
-import data.lib.core
+import data.lib.core.format_with_id
+import data.lib.core.kind
+import data.lib.core.name
 import data.lib.pods
 
 policyID := "P1004"
@@ -199,7 +201,7 @@ policyID := "P1004"
 violation[msg] {
   pod_host_alias
 
-  msg := core.format_with_id(sprintf("%s/%s: Pod has hostAliases defined", [core.kind, core.name]), policyID)
+  msg := format_with_id(sprintf("%s/%s: Pod has hostAliases defined", [kind, name]), policyID)
 }
 
 pod_host_alias {

--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -732,7 +732,15 @@ func getRecursiveImportPaths(regoFile *loader.RegoFile, regoFiles map[string]*lo
 
 		imported := regoFiles[importPath]
 		if imported == nil {
-			return nil, fmt.Errorf("import not found: %s", importPath)
+			// It is possible that the import is for a specific rule in a package
+			// rather than for the package itself. To check for this, we remove
+			// the last element in the import path and check again.
+			split := strings.Split(importPath, ".")
+			parent := strings.Join(split[0:len(split)-1], ".")
+			imported = regoFiles[parent]
+			if imported == nil {
+				return nil, fmt.Errorf("import not found: %s", importPath)
+			}
 		}
 
 		recursiveImports = append(recursiveImports, imported.Parsed.Package.Path.String())


### PR DESCRIPTION
This allows Konstraint to resolve the libraries to import when users
import a specific rule rather than a package.

Signed-off-by: James Alseth <james@jalseth.me>

---

Fixes #270 