### PR TITLE
Fix OPA Metadata parameters validation (fix #293)

### DIFF
--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -126,7 +126,7 @@ func runCreateCommand(path string) error {
 		}
 
 		// Skip Constraint generation if there are parameters on the template.
-		if len(violation.Parameters()) > 0 && !viper.GetBool("partial-constraints") {
+		if !viper.GetBool("partial-constraints") && (len(violation.Parameters()) > 0 || len(violation.AnnotationParameters()) > 0) {
 			logger.Warn("Skipping constraint generation due to use of parameters")
 			continue
 		}


### PR DESCRIPTION
I've also removed what seems to be a duplicating parameters checking code: if I understood the code correctly, `paramDiff` check is enough and `for _, bodyParam := range bodyParams` would never be reached.