### PR TITLE
Add support for skip-template annotation

### DIFF
--- a/docs/constraint_creation.md
+++ b/docs/constraint_creation.md
@@ -103,9 +103,12 @@ violation[{"msg": msg}] {
 }
 ```
 
-### Skipping generation of the Constraint resource
+### Skipping generation of the Constraint and/or ConstraintTemplate resource
 
 In some scenarios, you may wish for Konstraint to skip the generation of the `Constraint` resource for a policy and manage that externally. To do so, add the `skipConstraint: true` annotation in the custom metadata section.
+
+You can also skip the generation of both the `Constraint` and `ConstraintTemplate` resource with the `skipTemplate: true` annotation
+in the custom metadata section.
 
 ### Legacy annotations
 Previously Konstraint had custom annotation format, such as `@title` or `@kinds`, which is a legacy format and will be removed in future releases.

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -85,6 +85,11 @@ func runCreateCommand(path string) error {
 			"src":  violation.Path(),
 		})
 
+		if violation.SkipTemplate() {
+			logger.Info("Skipping constrainttemplate generation due to configuration")
+			continue
+		}
+
 		if !isValidEnforcementAction(violation.Enforcement()) {
 			return fmt.Errorf("enforcement action (%v) is invalid in policy: %s", violation.Enforcement(), violation.Path())
 		}

--- a/internal/rego/rego_test.go
+++ b/internal/rego/rego_test.go
@@ -248,6 +248,20 @@ func TestGetHeaderParams(t *testing.T) {
 	}
 }
 
+func TestHasSkipTemplateTag(t *testing.T) {
+	comments := []string{
+		"@title Title",
+		"Description",
+		"@kinds another/thing",
+		"@skip-template",
+	}
+
+	skip := hasSkipTemplateTag(comments)
+	if !skip {
+		t.Error("SkipTemplate is false when the @skip-template comment tag is present")
+	}
+}
+
 func TestHasSkipConstraintTag(t *testing.T) {
 	comments := []string{
 		"@title Title",


### PR DESCRIPTION
Allows skipping the create of the ConstraintTemplate object (and the Constraint) when the `skipTemplate: true` custom annotation is set.