### PR TITLE
Fix a bug that the parameters section in the policies.md is not formatted correctly

### DIFF
--- a/examples/policies-no-rego.md
+++ b/examples/policies-no-rego.md
@@ -37,7 +37,7 @@
 
 **Parameters:**
 
-* labels: array of string<br>
+* labels: array of string
   Array of required label keys.
 
 This policy allows you to require certain labels are set on a resource. Adapted from https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -37,7 +37,7 @@
 
 **Parameters:**
 
-* labels: array of string<br>
+* labels: array of string
   Array of required label keys.
 
 This policy allows you to require certain labels are set on a resource. Adapted from https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml

--- a/internal/commands/document_template.go
+++ b/internal/commands/document_template.go
@@ -25,10 +25,9 @@ const docTemplate = `# Policies
 {{- if .Header.Parameters }}
 
 **Parameters:**
-
-{{ range .Header.Parameters -}}
+{{ range .Header.Parameters }}
 * {{ .Name }}: {{ if .IsArray }}array of {{ end }}{{ .Type }}
-{{- if .Description }}<br>
+{{- if .Description }}
   {{ .Description }}{{- end -}}
 {{ end }}
 {{- end }}


### PR DESCRIPTION
# Summary
Fix a bug that the parameters section in the policies.md is not formatted correctly when multiple parameters is specified.

# Confirmation steps
1. Prepare a file like the following (Rego file with multiple parameters)
```rego
# METADATA
# title: Test policy
# custom:
#   parameters:
#     param_1:
#       type: array
#       description: this is param 1.
#       items:
#         type: string
#     param_2:
#       type: string
#       description: this is param 2.
#     param_3:
#       type: integer
package test_policy

violation[msg] {
	msg := "foo"
}
```

2. With the current version of konstraint, run the `konstraint doc` and confirm that the contents of parameters in policies.md are not properly formatted.
```md
**Parameters:**

* param_1: array of string<br>
  this is param 1.* param_2: string<br>
  this is param 2.* param_3: integer
```

<img width="242" alt="image" src="https://user-images.githubusercontent.com/26561120/178907833-1d75c2d2-173b-41b1-a98b-8cb5d5c14075.png">


3. With the fixed version of konstraint, run the `konstraint doc` and confirm that the contents of parameters in policies.md are properly formatted.
```md
**Parameters:**

* param_1: array of string
  this is param 1.
* param_2: string
  this is param 2.
* param_3: integer
```

<img width="211" alt="image" src="https://user-images.githubusercontent.com/26561120/178907872-3d4c6624-5baf-4074-9fe2-cc9272a1aee2.png">
