### PR TITLE
Fix failing PR workflows

### DIFF
--- a/.github/workflows/cron_e2e.yaml
+++ b/.github/workflows/cron_e2e.yaml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - name: checkout source
         uses: actions/checkout@v3
+
       - name: fetch gatekeeper versions
         id: fetch-gk-versions
         working-directory: .github/scripts
@@ -46,6 +47,7 @@ jobs:
     strategy:
       matrix:
         gk-version: ${{ fromJson(needs.e2e-prep.outputs.gk-versions) }}
+
     steps:
       - name: checkout source
         uses: actions/checkout@v3
@@ -63,14 +65,14 @@ jobs:
 
       - name: create kind cluster
         run: kind create cluster
-      
+
       - name: install gatekeeper
         env:
           GK_VERSION: ${{ matrix.gk-version }}
         run: |
           helm repo add gk https://open-policy-agent.github.io/gatekeeper/charts
           kubectl create ns gatekeeper-system
-          helm install gatekeeper gk/gatekeeper -n gatekeeper-system --set replicas=1 --version ${GK_VERSION}
+          helm install gatekeeper gk/gatekeeper -n gatekeeper-system --set replicas=1 --version ${GK_VERSION} --set psp.enabled=false
 
       - name: apply resources
         working-directory: e2e-resources

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: setup go
         uses: actions/setup-go@v3
@@ -73,6 +74,7 @@ jobs:
     name: Docker Tests
     needs: [lint]
     runs-on: ubuntu-latest
+
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -89,6 +91,7 @@ jobs:
   policy-tests:
     name: Policy Tests
     runs-on: ubuntu-latest
+
     container: openpolicyagent/conftest:latest
     steps:
       - name: checkout source
@@ -106,9 +109,11 @@ jobs:
     needs:
       - lint
       - acceptance
+
     steps:
       - name: checkout source
         uses: actions/checkout@v3
+
       - name: fetch gatekeeper versions
         id: fetch-gk-versions
         working-directory: .github/scripts
@@ -124,6 +129,7 @@ jobs:
     strategy:
       matrix:
         gk-version: ${{ fromJson(needs.e2e-prep.outputs.gk-versions) }}
+
     steps:
       - name: checkout source
         uses: actions/checkout@v3
@@ -141,14 +147,14 @@ jobs:
 
       - name: create kind cluster
         run: kind create cluster
-      
+
       - name: install gatekeeper
         env:
           GK_VERSION: ${{ matrix.gk-version }}
         run: |
           helm repo add gk https://open-policy-agent.github.io/gatekeeper/charts
           kubectl create ns gatekeeper-system
-          helm install gatekeeper gk/gatekeeper -n gatekeeper-system --set replicas=1 --version ${GK_VERSION}
+          helm install gatekeeper gk/gatekeeper -n gatekeeper-system --set replicas=1 --version ${GK_VERSION} --set psp.enabled=false
 
       - name: apply resources
         working-directory: e2e-resources

--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+
     steps:
     - name: setup go
       uses: actions/setup-go@v3
@@ -23,8 +24,9 @@ jobs:
       run: make build
 
   container-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [unit-test]
+
     steps:
     - name: checkout
       uses: actions/checkout@v3

--- a/.github/workflows/update_cli_docs.yaml
+++ b/.github/workflows/update_cli_docs.yaml
@@ -12,6 +12,7 @@ jobs:
   update-docs:
     name: Update CLI Docs
     runs-on: ubuntu-latest
+
     steps:
       - name: setup go
         uses: actions/setup-go@v3
@@ -22,9 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: generate docs
-        run: |
-          go mod download
-          go run .github/gendocs/konstraint.go
+        run: go run -mod=mod .github/gendocs/konstraint.go
 
       - name: commit changes
         uses: EndBug/add-and-commit@v9

--- a/docs/cli/konstraint.md
+++ b/docs/cli/konstraint.md
@@ -14,6 +14,7 @@ A tool to create and manage Gatekeeper CRDs from Rego
 
 ### SEE ALSO
 
+* [konstraint convert](konstraint_convert.md)	 - Convert legacy annotations to OPA Metadata Annotations
 * [konstraint create](konstraint_create.md)	 - Create Gatekeeper constraints from Rego policies
 * [konstraint doc](konstraint_doc.md)	 - Generate documentation from Rego policies
 

--- a/internal/commands/convert.go
+++ b/internal/commands/convert.go
@@ -60,7 +60,7 @@ func runConvertCommand(path string) error {
 		var sb strings.Builder
 		sb.WriteString("# METADATA\n")
 
-		// force order: `title`, `description`, `custom`
+		// Force order: `title`, `description`, `custom`
 		if conveted.Title != "" {
 			yml, err := yaml.Marshal(&rego.ConvertedLegacyAnnotations{Title: conveted.Title})
 			if err != nil {


### PR DESCRIPTION
PRs are failing on the E2E tests due to testing on v1.25+ versions of Kubernetes due to the policy API no longer existing. (ref: https://github.com/plexsystems/konstraint/pull/329)

There is also an issue with documentation generation where `go run` fails because the `go.mod` is outdated, but it shouldn't be used for this process.