### PR TITLE
Update pipelines to use 1.19

### DIFF
--- a/.github/workflows/cron_e2e.yaml
+++ b/.github/workflows/cron_e2e.yaml
@@ -8,15 +8,19 @@ jobs:
   build:
     name: Build latest binary
     runs-on: ubuntu-latest
+
     steps:
       - name: setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
+
       - name: checkout source
         uses: actions/checkout@v3
+
       - name: build
         run: make build
+
       - name: upload build
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: checkout
         uses: actions/checkout@v3
@@ -17,7 +17,7 @@ jobs:
       - name: lint go
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: v1.49
           args: --timeout=5m --color=always --max-same-issues=0 --max-issues-per-linter=0
 
   acceptance:
@@ -31,7 +31,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - name: checkout
       uses: actions/checkout@v3

--- a/.github/workflows/update_cli_docs.yaml
+++ b/.github/workflows/update_cli_docs.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: 1.19.x
 
       - name: checkout source
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plexsystems/konstraint
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/internal/commands/convert.go
+++ b/internal/commands/convert.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -89,7 +89,7 @@ func runConvertCommand(path string) error {
 		sb.WriteString(r.LegacyConversionSource())
 		sb.WriteByte('\n')
 
-		if err := ioutil.WriteFile(r.Path(), []byte(sb.String()), 0644); err != nil {
+		if err := os.WriteFile(r.Path(), []byte(sb.String()), 0644); err != nil {
 			return fmt.Errorf("writing updated policy source: %w", err)
 		}
 

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -111,21 +110,19 @@ func runCreateCommand(path string) error {
 		var constraintTemplate any
 		switch constraintTemplateVersion {
 		case "v1":
-			constraintTemplate, err = getConstraintTemplatev1(violation, logger)
+			constraintTemplate = getConstraintTemplatev1(violation, logger)
 		case "v1beta1":
-			constraintTemplate, err = getConstraintTemplatev1beta1(violation, logger)
+			constraintTemplate = getConstraintTemplatev1beta1(violation, logger)
 		default:
 			return fmt.Errorf("unsupported API version for constrainttemplate: %s", constraintTemplateVersion)
 		}
-		if err != nil {
-			return fmt.Errorf("build constrainttemplate: %w", err)
-		}
+
 		constraintTemplateBytes, err := yaml.Marshal(constraintTemplate)
 		if err != nil {
 			return fmt.Errorf("marshal constrainttemplate: %w", err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(outputDir, templateFileName), constraintTemplateBytes, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(outputDir, templateFileName), constraintTemplateBytes, 0644); err != nil {
 			return fmt.Errorf("writing template: %w", err)
 		}
 
@@ -150,7 +147,7 @@ func runCreateCommand(path string) error {
 			return fmt.Errorf("marshal constraint: %w", err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(outputDir, constraintFileName), constraintBytes, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(outputDir, constraintFileName), constraintBytes, 0644); err != nil {
 			return fmt.Errorf("writing constraint: %w", err)
 		}
 	}
@@ -160,7 +157,7 @@ func runCreateCommand(path string) error {
 	return nil
 }
 
-func getConstraintTemplatev1(violation rego.Rego, logger *log.Entry) (*v1.ConstraintTemplate, error) {
+func getConstraintTemplatev1(violation rego.Rego, logger *log.Entry) *v1.ConstraintTemplate {
 	constraintTemplate := v1.ConstraintTemplate{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "templates.gatekeeper.sh/v1",
@@ -209,10 +206,10 @@ func getConstraintTemplatev1(violation rego.Rego, logger *log.Entry) (*v1.Constr
 		}
 	}
 
-	return &constraintTemplate, nil
+	return &constraintTemplate
 }
 
-func getConstraintTemplatev1beta1(violation rego.Rego, logger *log.Entry) (*v1beta1.ConstraintTemplate, error) {
+func getConstraintTemplatev1beta1(violation rego.Rego, logger *log.Entry) *v1beta1.ConstraintTemplate {
 	constraintTemplate := v1beta1.ConstraintTemplate{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "templates.gatekeeper.sh/v1beta1",
@@ -259,7 +256,7 @@ func getConstraintTemplatev1beta1(violation rego.Rego, logger *log.Entry) (*v1be
 		}
 	}
 
-	return &constraintTemplate, nil
+	return &constraintTemplate
 }
 
 func getConstraint(violation rego.Rego, logger *log.Entry) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
Followup to https://github.com/plexsystems/konstraint/pull/329

Upgrades the codebase to 1.19 and fixes the new linting errors.