### PR TITLE
Update test data to use OPA metadata

### DIFF
--- a/docs/constraint_creation.md
+++ b/docs/constraint_creation.md
@@ -111,6 +111,7 @@ You can also skip the generation of both the `Constraint` and `ConstraintTemplat
 in the custom metadata section.
 
 ### Legacy annotations
+
 Previously Konstraint had custom annotation format, such as `@title` or `@kinds`, which is a legacy format and will be removed in future releases.
 
 To aid with transition to OPA Metadata format, a conversion tool is provided as `konstraint convert`
@@ -138,23 +139,24 @@ package required_labels
 import data.lib.core
 
 violation[msg] {
-	missing := missing_labels
-	count(missing) > 0
+    missing := missing_labels
+    count(missing) > 0
 
-	msg := sprintf("%s/%s: Missing required labels: %v", [core.kind, core.name, missing])
+    msg := sprintf("%s/%s: Missing required labels: %v", [core.kind, core.name, missing])
 }
 
 missing_labels = missing {
-	provided := {label | core.labels[label]}
-	required := {label | label := input.parameters.labels[_]}
-	missing := required - provided
+    provided := {label | core.labels[label]}
+    required := {label | label := input.parameters.labels[_]}
+    missing := required - provided
 }
 ```
+
 ## Setting constraint metadata.annotations and metadata.labels
 
-You can optionally specify annotations and labels for the generated Constraint. This can be useful if you use Argo CD for deployment (see [here](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types)). 
+You can optionally specify annotations and labels for the generated Constraint. This can be useful if you use Argo CD for deployment (see [here](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types)).
 
-```
+```rego
 # METADATA
 # title: Required Labels
 # description: >-

--- a/test/src.rego
+++ b/test/src.rego
@@ -1,14 +1,41 @@
-# @title The title
-#
-# The description
-#
-# @kinds apps/DaemonSet apps/Deployment apps/StatefulSet core/Pod
-# @matchExpression foo In bar,baz
-# @matchExpression doggos Exists
-# @namespaces dev stage prod
-# @excludedNamespaces kube-system gatekeeper-system
-# @parameter super string -- super duper cool parameter
-# -- with a description on two strings
+# METADATA
+# title: The title
+# description: The description
+# custom:
+#   parameters:
+#     super:
+#       type: string
+#       description: |-
+#         super duper cool parameter with a description
+#         on two lines.
+#   matchers:
+#     excludedNamespaces:
+#     - kube-system
+#     - gatekeeper-system
+#     kinds:
+#     - apiGroups:
+#       - ""
+#       kinds:
+#       - Pod
+#     - apiGroups:
+#       - apps
+#       kinds:
+#       - DaemonSet
+#       - Deployment
+#       - StatefulSet
+#     labelSelector:
+#       matchExpressions:
+#       - key: foo
+#         operator: In
+#         values:
+#         - bar
+#         - baz
+#       - key: doggos
+#         operator: Exists
+#     namespaces:
+#     - dev
+#     - stage
+#     - prod
 package test
 
 import data.lib.libraryA
@@ -16,5 +43,5 @@ import data.lib.libraryA
 policyID := "P123456"
 
 violation[{"msg": "msg"}] {
-    true # some comment with a trailing space 
+    true # some comment
 }

--- a/test/template_Test.yaml
+++ b/test/template_Test.yaml
@@ -12,7 +12,9 @@ spec:
         openAPIV3Schema:
           properties:
             super:
-              description: super duper cool parameter with a description on two strings
+              description: |-
+                super duper cool parameter with a description
+                on two lines.
               type: string
   targets:
   - libs:
@@ -29,7 +31,7 @@ spec:
       policyID := "P123456"
 
       violation[{"msg": "msg"}] {
-          true # some comment with a trailing space
+          true # some comment
       }
     target: admission.k8s.gatekeeper.sh
 status: {}


### PR DESCRIPTION
Relates to: https://github.com/plexsystems/konstraint/issues/297

This will be a large-ish effort so in order to keep the diffs manageable, this PR just updates the test Rego to use the new matchers and lints some documentation.