### PR TITLE
Use environment file for GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/cron_e2e.yaml
+++ b/.github/workflows/cron_e2e.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: fetch gatekeeper versions
         id: fetch-gk-versions
         working-directory: .github/scripts
-        run: echo "::set-output name=gk-versions::$(./fetch_gk_versions.sh)"
+        run: echo "gk-versions=$(./fetch_gk_versions.sh)" >> $GITHUB_OUTPUT
     outputs:
       gk-versions: ${{ steps.fetch-gk-versions.outputs.gk-versions }}
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: fetch gatekeeper versions
         id: fetch-gk-versions
         working-directory: .github/scripts
-        run: echo "::set-output name=gk-versions::$(./fetch_gk_versions.sh)"
+        run: echo "gk-versions=$(./fetch_gk_versions.sh)" >> $GITHUB_OUTPUT
     outputs:
       gk-versions: ${{ steps.fetch-gk-versions.outputs.gk-versions }}
 


### PR DESCRIPTION
The set-output command has been deprecated and will stop workin in 2023.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: James Alseth <james@jalseth.me>