### PR TITLE
feat: Support custom doc template

### DIFF
--- a/docs/cli/konstraint_doc.md
+++ b/docs/cli/konstraint_doc.md
@@ -22,11 +22,12 @@ Set the URL where the policies are hosted at
 ### Options
 
 ```
-  -h, --help               help for doc
-      --include-comments   Include comments from the rego source in the documentation
-      --no-rego            Do not include the Rego in the policy documentation
-  -o, --output string      Output location (including filename) for the policy documentation (default "policies.md")
-      --url string         The URL where the policy files are hosted at (e.g. https://github.com/policies)
+  -h, --help                   help for doc
+      --include-comments       Include comments from the rego source in the documentation
+      --no-rego                Do not include the Rego in the policy documentation
+  -o, --output string          Output location (including filename) for the policy documentation (default "policies.md")
+      --template-file string   File to read the template from (default: "")
+      --url string             The URL where the policy files are hosted at (e.g. https://github.com/policies)
 ```
 
 ### SEE ALSO

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,9 @@ type Document struct {
 	URL    string
 	Rego   string
 }
+
+//go:embed document_template.tpl
+var docTemplate string
 
 func newDocCommand() *cobra.Command {
 	cmd := cobra.Command{

--- a/internal/commands/document_template.tpl
+++ b/internal/commands/document_template.tpl
@@ -1,6 +1,4 @@
-package commands
-
-const docTemplate = `# Policies
+# Policies
 {{ range $severity, $value := . }}
 ## {{ $severity }}{{- if ne $severity "Not Enforced" }}s{{ end }}
 
@@ -35,7 +33,7 @@ const docTemplate = `# Policies
 {{ .Header.Description }}
 {{ if ne .Rego "" }}
 ### Rego
-{{ $codeblock := "` + "```" + `" }}
+{{ $codeblock := "```" }}
 {{ $codeblock }}rego
 {{ .Rego }}
 {{ $codeblock }}{{- end }}
@@ -43,4 +41,4 @@ const docTemplate = `# Policies
 _source: [{{ .URL }}]({{ .URL }})_
 {{ end }}
 
-{{- end }}`
+{{- end }}


### PR DESCRIPTION
This allows to provide a custom doc template instead of https://github.com/plexsystems/konstraint/blob/main/internal/commands/document_template.go which allows to use different output formats (e.g. custom html website or similar)