### PR TITLE
deps: Move to sigs.k8s.io/yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/plexsystems/konstraint
 go 1.19
 
 require (
-	github.com/ghodss/yaml v1.0.0
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20220218180203-c2a0d8cdf85a
 	github.com/open-policy-agent/opa v0.55.0
 	github.com/sirupsen/logrus v1.9.3
@@ -12,6 +11,7 @@ require (
 	golang.org/x/text v0.12.0
 	k8s.io/apiextensions-apiserver v0.28.1
 	k8s.io/apimachinery v0.28.1
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -24,6 +24,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -86,5 +87,4 @@ require (
 	sigs.k8s.io/controller-runtime v0.11.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/internal/commands/convert.go
+++ b/internal/commands/convert.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/plexsystems/konstraint/internal/rego"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 func newConvertCommand() *cobra.Command {

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/plexsystems/konstraint/internal/rego"
 
-	"github.com/ghodss/yaml"
 	v1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	log "github.com/sirupsen/logrus"
@@ -18,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
 )
 
 const (


### PR DESCRIPTION
https://github.com/kubernetes-sigs/yaml is a more active fork of github.com/ghodss/yaml.