### PR TITLE
fix: cover empty securityContext in container_deny_escalation

### DIFF
--- a/examples/container-deny-escalation/src.rego
+++ b/examples/container-deny-escalation/src.rego
@@ -35,5 +35,9 @@ container_allows_escalation(c) {
 }
 
 container_allows_escalation(c) {
+	core.missing_field(c, "securityContext")
+}
+
+container_allows_escalation(c) {
 	core.missing_field(c.securityContext, "allowPrivilegeEscalation")
 }


### PR DESCRIPTION
Closes https://github.com/plexsystems/konstraint/issues/447