### PR TITLE
Add Regal for linting Rego

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -88,6 +88,30 @@ jobs:
       - name: test doc command
         run: docker run -v $PWD:/konstraint konstraint doc /konstraint/examples
 
+  policy-checks:
+    name: Policy Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v4
+
+      - name: setup opa
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: latest
+
+      - name: opa check strict
+        run: opa check --strict --ignore "*.yaml" examples
+
+      - name: setup regal
+        uses: styrainc/setup-regal@v0.2.0
+        with:
+          version: 0.12.0
+
+      - name: regal lint
+        run: regal lint --format github examples
+
   policy-tests:
     name: Policy Tests
     runs-on: ubuntu-latest

--- a/examples/.regal/config.yaml
+++ b/examples/.regal/config.yaml
@@ -1,0 +1,22 @@
+rules:
+  bugs:
+    inconsistent-args:
+      level: ignore
+  idiomatic:
+    no-defined-entrypoint:
+      level: ignore
+  imports:
+    prefer-package-imports:
+      level: ignore
+  style:
+    line-length:
+      level: error
+      max-line-length: 120
+      non-breakable-word-threshold: 50
+    prefer-some-in-iteration:
+      level: ignore
+    prefer-snake-case:
+      level: ignore
+  testing:
+    test-outside-test-package:
+      level: ignore

--- a/examples/any-warn-deprecated-api-versions/src.rego
+++ b/examples/any-warn-deprecated-api-versions/src.rego
@@ -14,14 +14,17 @@
 #       - Deployment
 package any_warn_deprecated_api_versions
 
-policyID := "P0001"
-
 import data.lib.core
+
+policyID := "P0001"
 
 warn[msg] {
 	resources := ["DaemonSet", "Deployment"]
 	core.apiVersion == "extensions/v1beta1"
 	core.kind == resources[_]
 
-	msg := core.format_with_id(sprintf("API extensions/v1beta1 for %s has been deprecated, use apps/v1 instead.", [core.kind]), policyID)
+	msg := core.format_with_id(
+		sprintf("API extensions/v1beta1 for %s has been deprecated, use apps/v1 instead.", [core.kind]),
+		policyID,
+	)
 }

--- a/examples/any-warn-deprecated-api-versions/src_test.rego
+++ b/examples/any-warn-deprecated-api-versions/src_test.rego
@@ -1,34 +1,28 @@
 package any_warn_deprecated_api_versions
 
 test_matching {
-	input := {
+	warns := warn with input as {
 		"kind": "Deployment",
 		"metadata": {"name": "test"},
 		"apiVersion": "extensions/v1beta1",
 	}
-
-	warns := warn with input as input
 	count(warns) == 1
 }
 
 test_different_kind {
-	input := {
+	warns := warn with input as {
 		"kind": "test",
 		"metadata": {"name": "test"},
 		"apiVersion": "extensions/v1beta1",
 	}
-
-	warns := warn with input as input
 	count(warns) == 0
 }
 
 test_different_apiversion {
-	input := {
+	warns := warn with input as {
 		"kind": "Deployment",
 		"metadata": {"name": "test"},
 		"apiVersion": "test",
 	}
-
-	warns := warn with input as input
 	count(warns) == 0
 }

--- a/examples/container-deny-added-caps/src.rego
+++ b/examples/container-deny-added-caps/src.rego
@@ -28,10 +28,14 @@ import data.lib.security
 policyID := "P1001"
 
 violation[msg] {
+	some container
 	pods.containers[container]
 	not container_dropped_all_capabilities(container)
 
-	msg := core.format_with_id(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]),
+		policyID,
+	)
 }
 
 container_dropped_all_capabilities(container) {

--- a/examples/container-deny-added-caps/src_test.rego
+++ b/examples/container-deny-added-caps/src_test.rego
@@ -1,13 +1,9 @@
 package container_deny_added_caps
 
 test_dropped_all {
-	input := {"securityContext": {"capabilities": {"drop": ["all"]}}}
-
-	container_dropped_all_capabilities(input)
+	container_dropped_all_capabilities({"securityContext": {"capabilities": {"drop": ["all"]}}})
 }
 
 test_dropped_none {
-	input := {"securityContext": {"capabilities": {"drop": ["none"]}}}
-
-	not container_dropped_all_capabilities(input)
+	not container_dropped_all_capabilities({"securityContext": {"capabilities": {"drop": ["none"]}}})
 }

--- a/examples/container-deny-added-caps/template.yaml
+++ b/examples/container-deny-added-caps/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     - |-
       package lib.security
 
@@ -131,10 +127,14 @@ spec:
       policyID := "P1001"
 
       violation[msg] {
+        some container
         pods.containers[container]
         not container_dropped_all_capabilities(container)
 
-        msg := core.format_with_id(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]),
+          policyID,
+        )
       }
 
       container_dropped_all_capabilities(container) {

--- a/examples/container-deny-escalation/src.rego
+++ b/examples/container-deny-escalation/src.rego
@@ -24,6 +24,7 @@ import data.lib.pods
 policyID := "P1002"
 
 violation[msg] {
+	some container
 	pods.containers[container]
 	container_allows_escalation(container)
 

--- a/examples/container-deny-escalation/src_test.rego
+++ b/examples/container-deny-escalation/src_test.rego
@@ -1,13 +1,9 @@
 package container_deny_escalation
 
 test_allowescalation_false {
-	input := {"securityContext": {"allowPrivilegeEscalation": false}}
-
-	not container_allows_escalation(input)
+	not container_allows_escalation({"securityContext": {"allowPrivilegeEscalation": false}})
 }
 
 test_allowescalation_true {
-	input := {"securityContext": {"allowPrivilegeEscalation": true}}
-
-	container_allows_escalation(input)
+	container_allows_escalation({"securityContext": {"allowPrivilegeEscalation": true}})
 }

--- a/examples/container-deny-escalation/template.yaml
+++ b/examples/container-deny-escalation/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package container_deny_escalation
 
@@ -108,6 +104,7 @@ spec:
       policyID := "P1002"
 
       violation[msg] {
+        some container
         pods.containers[container]
         container_allows_escalation(container)
 

--- a/examples/container-deny-latest-tag/src.rego
+++ b/examples/container-deny-latest-tag/src.rego
@@ -39,10 +39,14 @@ import data.lib.pods
 policyID := "P2001"
 
 violation[msg] {
+	some container
 	pods.containers[container]
 	has_latest_tag(container)
 
-	msg := core.format_with_id(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]),
+		policyID,
+	)
 }
 
 has_latest_tag(c) {

--- a/examples/container-deny-latest-tag/src_test.rego
+++ b/examples/container-deny-latest-tag/src_test.rego
@@ -1,19 +1,13 @@
 package container_deny_latest_tag
 
 test_input_as_image_without_latest_tag {
-	input := {"name": "test", "image": "image:1.0.0"}
-
-	not has_latest_tag(input)
+	not has_latest_tag({"name": "test", "image": "image:1.0.0"})
 }
 
 test_input_as_image_with_latest_tag {
-	input := {"name": "test", "image": "image:latest"}
-
-	has_latest_tag(input)
+	has_latest_tag({"name": "test", "image": "image:latest"})
 }
 
 test_input_as_image_with_no_tag {
-	input := {"name": "test", "image": "image"}
-
-	has_latest_tag(input)
+	has_latest_tag({"name": "test", "image": "image"})
 }

--- a/examples/container-deny-latest-tag/template.yaml
+++ b/examples/container-deny-latest-tag/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package container_deny_latest_tag
 
@@ -108,10 +104,14 @@ spec:
       policyID := "P2001"
 
       violation[msg] {
+        some container
         pods.containers[container]
         has_latest_tag(container)
 
-        msg := core.format_with_id(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]),
+          policyID,
+        )
       }
 
       has_latest_tag(c) {

--- a/examples/container-deny-privileged-if-tenant/src.rego
+++ b/examples/container-deny-privileged-if-tenant/src.rego
@@ -31,10 +31,14 @@ import data.lib.security
 policyID := "P2006"
 
 violation[msg] {
+	some container
 	pods.containers[container]
 	container_is_privileged(container)
 
-	msg = core.format_with_id(sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+	msg = core.format_with_id(
+		sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]),
+		policyID,
+	)
 }
 
 container_is_privileged(container) {

--- a/examples/container-deny-privileged-if-tenant/src_test.rego
+++ b/examples/container-deny-privileged-if-tenant/src_test.rego
@@ -1,19 +1,13 @@
 package container_deny_privileged
 
 test_privileged_true {
-	input := {"securityContext": {"privileged": true}}
-
-	container_is_privileged(input)
+	container_is_privileged({"securityContext": {"privileged": true}})
 }
 
 test_privileged_false {
-	input := {"securityContext": {"privileged": false}}
-
-	not container_is_privileged(input)
+	not container_is_privileged({"securityContext": {"privileged": false}})
 }
 
 test_added_capability {
-	input := {"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}}
-
-	container_is_privileged(input)
+	container_is_privileged({"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}})
 }

--- a/examples/container-deny-privileged-if-tenant/template.yaml
+++ b/examples/container-deny-privileged-if-tenant/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     - |-
       package lib.security
 
@@ -131,10 +127,14 @@ spec:
       policyID := "P2006"
 
       violation[msg] {
+        some container
         pods.containers[container]
         container_is_privileged(container)
 
-        msg = core.format_with_id(sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+        msg = core.format_with_id(
+          sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]),
+          policyID,
+        )
       }
 
       container_is_privileged(container) {

--- a/examples/container-deny-privileged/src.rego
+++ b/examples/container-deny-privileged/src.rego
@@ -26,10 +26,14 @@ import data.lib.security
 policyID := "P1003"
 
 violation[msg] {
+	some container
 	pods.containers[container]
 	container_is_privileged(container)
 
-	msg = core.format_with_id(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]),
+		policyID,
+	)
 }
 
 container_is_privileged(container) {

--- a/examples/container-deny-privileged/src_test.rego
+++ b/examples/container-deny-privileged/src_test.rego
@@ -1,19 +1,13 @@
 package container_deny_privileged
 
 test_privileged_true {
-	input := {"securityContext": {"privileged": true}}
-
-	container_is_privileged(input)
+	container_is_privileged({"securityContext": {"privileged": true}})
 }
 
 test_privileged_false {
-	input := {"securityContext": {"privileged": false}}
-
-	not container_is_privileged(input)
+	not container_is_privileged({"securityContext": {"privileged": false}})
 }
 
 test_added_capability {
-	input := {"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}}
-
-	container_is_privileged(input)
+	container_is_privileged({"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}})
 }

--- a/examples/container-deny-privileged/template.yaml
+++ b/examples/container-deny-privileged/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     - |-
       package lib.security
 
@@ -131,10 +127,14 @@ spec:
       policyID := "P1003"
 
       violation[msg] {
+        some container
         pods.containers[container]
         container_is_privileged(container)
 
-        msg = core.format_with_id(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]),
+          policyID,
+        )
       }
 
       container_is_privileged(container) {

--- a/examples/container-deny-without-resource-constraints/src.rego
+++ b/examples/container-deny-without-resource-constraints/src.rego
@@ -24,10 +24,14 @@ import data.lib.pods
 policyID := "P2002"
 
 violation[msg] {
+	some container
 	pods.containers[container]
 	not container_resources_provided(container)
 
-	msg := core.format_with_id(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]),
+		policyID,
+	)
 }
 
 container_resources_provided(container) {

--- a/examples/container-deny-without-resource-constraints/template.yaml
+++ b/examples/container-deny-without-resource-constraints/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package container_deny_without_resource_constraints
 
@@ -108,10 +104,14 @@ spec:
       policyID := "P2002"
 
       violation[msg] {
+        some container
         pods.containers[container]
         not container_resources_provided(container)
 
-        msg := core.format_with_id(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]),
+          policyID,
+        )
       }
 
       container_resources_provided(container) {

--- a/examples/container-warn-no-ro-fs/src.rego
+++ b/examples/container-warn-no-ro-fs/src.rego
@@ -24,10 +24,14 @@ import data.lib.pods
 policyID := "P2003"
 
 warn[msg] {
+	some container
 	pods.containers[container]
 	no_read_only_filesystem(container)
 
-	msg := core.format_with_id(sprintf("%s/%s/%s: Is not using a read only root filesystem", [core.kind, core.name, container.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s/%s: Is not using a read only root filesystem", [core.kind, core.name, container.name]),
+		policyID,
+	)
 }
 
 no_read_only_filesystem(container) {

--- a/examples/container-warn-no-ro-fs/src_test.rego
+++ b/examples/container-warn-no-ro-fs/src_test.rego
@@ -1,13 +1,9 @@
 package container_warn_no_ro_fs
 
 test_rofs_true {
-	input := {"securityContext": {"readOnlyRootFilesystem": true}}
-
-	not no_read_only_filesystem(input)
+	not no_read_only_filesystem({"securityContext": {"readOnlyRootFilesystem": true}})
 }
 
 test_rofs_false {
-	input := {"securityContext": {"readOnlyRootFilesystem": false}}
-
-	no_read_only_filesystem(input)
+	no_read_only_filesystem({"securityContext": {"readOnlyRootFilesystem": false}})
 }

--- a/examples/lib/core.rego
+++ b/examples/lib/core.rego
@@ -1,46 +1,44 @@
 package lib.core
 
-default is_gatekeeper = false
+default is_gatekeeper := false
 
 is_gatekeeper {
 	has_field(input, "review")
 	has_field(input.review, "object")
 }
 
-resource = input.review.object {
+resource := input.review.object {
 	is_gatekeeper
 }
 
-resource = input {
+resource := input {
 	not is_gatekeeper
 }
 
-format(msg) = {"msg": msg}
+format(msg) := {"msg": msg}
 
-format_with_id(msg, id) = msg_fmt {
-	msg_fmt := {
-		"msg": sprintf("%s: %s", [id, msg]),
-		"details": {"policyID": id},
-	}
+format_with_id(msg, id) := {
+	"msg": sprintf("%s: %s", [id, msg]),
+	"details": {"policyID": id},
 }
 
-apiVersion = resource.apiVersion
+apiVersion := resource.apiVersion
 
-name = resource.metadata.name
+name := resource.metadata.name
 
-kind = resource.kind
+kind := resource.kind
 
-labels = resource.metadata.labels
+labels := resource.metadata.labels
 
-annotations = resource.metadata.annotations
+annotations := resource.metadata.annotations
 
 gv := split(apiVersion, "/")
 
-group = gv[0] {
+group := gv[0] {
 	contains(apiVersion, "/")
 }
 
-group = "core" {
+group := "core" {
 	not contains(apiVersion, "/")
 }
 

--- a/examples/lib/core_test.rego
+++ b/examples/lib/core_test.rego
@@ -1,21 +1,17 @@
 package lib.core
 
 test_not_gk {
-	input := {"kind": "test"}
-	not is_gatekeeper with input as input
+	not is_gatekeeper with input as {"kind": "test"}
 }
 
 test_is_gk {
-	input := {"review": {"object": {"kind": "test"}}}
-	is_gatekeeper with input as input
+	is_gatekeeper with input as {"review": {"object": {"kind": "test"}}}
 }
 
 test_has_field_pos {
-	input := {"kind": "test"}
-	has_field(input, "kind")
+	has_field({"kind": "test"}, "kind")
 }
 
 test_missing_field {
-	input := {"kind": "test"}
-	not has_field(input, "abc")
+	not has_field({"kind": "test"}, "abc")
 }

--- a/examples/lib/pods.rego
+++ b/examples/lib/pods.rego
@@ -2,27 +2,25 @@ package lib.pods
 
 import data.lib.core
 
-default pod = false
+default pod := false
 
-pod = core.resource.spec.template {
+pod := core.resource.spec.template {
 	pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
 	lower(core.kind) == pod_templates[_]
 }
 
-pod = core.resource {
+pod := core.resource {
 	lower(core.kind) == "pod"
 }
 
-pod = core.resource.spec.jobTemplate.spec.template {
+pod := core.resource.spec.jobTemplate.spec.template {
 	lower(core.kind) == "cronjob"
 }
 
 containers[container] {
-	keys = {"containers", "initContainers"}
-	all_containers = [c | keys[k]; c = pod.spec[k][_]]
-	container = all_containers[_]
+	keys := {"containers", "initContainers"}
+	all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+	container := all_containers[_]
 }
 
-volumes[volume] {
-	volume = pod.spec.volumes[_]
-}
+volumes[pod.spec.volumes[_]]

--- a/examples/lib/pods_test.rego
+++ b/examples/lib/pods_test.rego
@@ -1,67 +1,55 @@
 package lib.pods
 
 test_input_as_other {
-	input := {
+	resource := pod with input as {
 		"kind": "Other",
 		"spec": {"containers": [{}]},
 	}
-
-	resource := pod with input as input
 
 	not resource
 }
 
 test_input_as_pod {
-	input := {
+	resource := pod with input as {
 		"kind": "Pod",
 		"spec": {"containers": [{}]},
 	}
-
-	resource := pod with input as input
 
 	resource.spec.containers
 }
 
 test_input_as_deployment {
-	input := {
+	resource := pod with input as {
 		"kind": "Deployment",
 		"spec": {"template": {"spec": {"containers": [{}]}}},
 	}
-
-	resource := pod with input as input
 
 	resource.spec.containers
 }
 
 test_input_as_cronjob {
-	input := {
+	resource := pod with input as {
 		"kind": "CronJob",
 		"spec": {"jobTemplate": {"spec": {"template": {"spec": {"containers": [{}]}}}}},
 	}
-
-	resource := pod with input as input
 
 	resource.spec.containers
 }
 
 test_containers {
-	input := {
+	podcontainers := containers with input as {
 		"kind": "Pod",
 		"spec": {"containers": [{"name": "container"}]},
 	}
-
-	podcontainers := containers with input as input
 
 	podcontainers[_].name == "container"
 }
 
 test_volumes {
-	input := {
+	podvolumes := volumes with input as {
 		"kind": "Pod",
 		"spec": {"volumes": [{"name": "volume"}]},
 	}
-
-	podvolumes := volumes with input as input
 
 	podvolumes[_].name == "volume"
 }

--- a/examples/lib/psp_test.rego
+++ b/examples/lib/psp_test.rego
@@ -1,11 +1,9 @@
 package lib.psps
 
 test_exception_pos {
-	input := {"metadata": {"name": "gce.privileged"}}
-	is_exception with input as input
+	is_exception with input as {"metadata": {"name": "gce.privileged"}}
 }
 
 test_exception_neg {
-	input := {"metadata": {"name": "test"}}
-	not is_exception with input as input
+	not is_exception with input as {"metadata": {"name": "test"}}
 }

--- a/examples/lib/rbac.rego
+++ b/examples/lib/rbac.rego
@@ -1,5 +1,7 @@
 package lib.rbac
 
+import future.keywords.in
+
 import data.lib.core
 
 rule_has_verb(rule, verb) {
@@ -13,9 +15,9 @@ rule_has_resource_type(rule, type) {
 }
 
 rule_has_resource_name(rule, name) {
-	name == rule.resourceNames[_]
+	name in rule.resourceNames
 }
 
-rule_has_resource_name(rule, name) {
+rule_has_resource_name(rule, _) {
 	core.missing_field(rule, "resourceNames")
 }

--- a/examples/lib/rbac_test.rego
+++ b/examples/lib/rbac_test.rego
@@ -1,55 +1,37 @@
 package lib.rbac
 
 test_rule_has_verb_with_use {
-	input := {"verbs": ["use"]}
-
-	rule_has_verb(input, "use")
+	rule_has_verb({"verbs": ["use"]}, "use")
 }
 
 test_rule_has_verb_with_asterisk {
-	input := {"verbs": ["*"]}
-
-	rule_has_verb(input, "use")
+	rule_has_verb({"verbs": ["*"]}, "use")
 }
 
 test_rule_has_verb_with_list {
-	input := {"verbs": ["list"]}
-
-	not rule_has_verb(input, "use")
+	not rule_has_verb({"verbs": ["list"]}, "use")
 }
 
 test_rule_has_resource_type_with_pod {
-	input := {"resources": ["Pod"]}
-
-	rule_has_resource_type(input, "pod")
+	rule_has_resource_type({"resources": ["Pod"]}, "pod")
 }
 
 test_rule_has_resource_type_with_resourceall {
-	input := {"resources": ["*"]}
-
-	rule_has_resource_type(input, "pod")
+	rule_has_resource_type({"resources": ["*"]}, "pod")
 }
 
 test_rule_has_resource_type_with_container {
-	input := {"resources": ["Container"]}
-
-	not rule_has_resource_type(input, "pod")
+	not rule_has_resource_type({"resources": ["Container"]}, "pod")
 }
 
 test_rule_has_resource_name_match {
-	input := {"resourceNames": ["test"]}
-
-	rule_has_resource_name(input, "test")
+	rule_has_resource_name({"resourceNames": ["test"]}, "test")
 }
 
 test_rule_has_resource_name_no_match {
-	input := {"resourceNames": ["test"]}
-
-	not rule_has_resource_name(input, "wrong")
+	not rule_has_resource_name({"resourceNames": ["test"]}, "wrong")
 }
 
 test_rule_has_resource_name_null {
-	input := {}
-
-	rule_has_resource_name(input, "wrong")
+	rule_has_resource_name({}, "wrong")
 }

--- a/examples/lib/security_test.rego
+++ b/examples/lib/security_test.rego
@@ -1,49 +1,33 @@
 package lib.security
 
 test_added_capabilities_container_match {
-	input := {"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}}
-
-	added_capability(input, "CAP_SYS_ADMIN")
+	added_capability({"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}}, "CAP_SYS_ADMIN")
 }
 
 test_added_capabilities_container_nomatch {
-	input := {"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}}
-
-	not added_capability(input, "test")
+	not added_capability({"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}}}, "test")
 }
 
 test_added_capabilities_psp_match {
-	input := {"spec": {"allowedCapabilities": ["CAP_SYS_ADMIN"]}}
-
-	added_capability(input, "CAP_SYS_ADMIN")
+	added_capability({"spec": {"allowedCapabilities": ["CAP_SYS_ADMIN"]}}, "CAP_SYS_ADMIN")
 }
 
 test_added_capabilities_psp_nomatch {
-	input := {"spec": {"allowedCapabilities": ["CAP_SYS_ADMIN"]}}
-
-	not added_capability(input, "test")
+	not added_capability({"spec": {"allowedCapabilities": ["CAP_SYS_ADMIN"]}}, "test")
 }
 
 test_dropped_capabilities_container_match {
-	input := {"securityContext": {"capabilities": {"drop": ["CAP_SYS_ADMIN"]}}}
-
-	dropped_capability(input, "CAP_SYS_ADMIN")
+	dropped_capability({"securityContext": {"capabilities": {"drop": ["CAP_SYS_ADMIN"]}}}, "CAP_SYS_ADMIN")
 }
 
 test_dropped_capabilities_container_nomatch {
-	input := {"securityContext": {"capabilities": {"drop": ["CAP_SYS_ADMIN"]}}}
-
-	not dropped_capability(input, "test")
+	not dropped_capability({"securityContext": {"capabilities": {"drop": ["CAP_SYS_ADMIN"]}}}, "test")
 }
 
 test_dropped_capabilities_psp_match {
-	input := {"spec": {"requiredDropCapabilities": ["CAP_SYS_ADMIN"]}}
-
-	dropped_capability(input, "CAP_SYS_ADMIN")
+	dropped_capability({"spec": {"requiredDropCapabilities": ["CAP_SYS_ADMIN"]}}, "CAP_SYS_ADMIN")
 }
 
 test_dropped_capabilities_psp_nomatch {
-	input := {"spec": {"requiredDropCapabilities": ["CAP_SYS_ADMIN"]}}
-
-	not dropped_capability(input, "test")
+	not dropped_capability({"spec": {"requiredDropCapabilities": ["CAP_SYS_ADMIN"]}}, "test")
 }

--- a/examples/pod-deny-host-alias/src_test.rego
+++ b/examples/pod-deny-host-alias/src_test.rego
@@ -1,19 +1,12 @@
 package pod_deny_host_alias
 
 test_input_with_alias_missing {
-	input := {
-		"kind": "Pod",
-		"spec": {},
-	}
-
-	not pod_host_alias with input as input
+	not pod_host_alias with input as {"kind": "Pod"}
 }
 
 test_input_with_alias {
-	input := {
+	pod_host_alias with input as {
 		"kind": "Pod",
 		"spec": {"hostAliases": [{"ip": "127.0.0.1", "hostnames": ["foo.local"]}]},
 	}
-
-	pod_host_alias with input as input
 }

--- a/examples/pod-deny-host-alias/template.yaml
+++ b/examples/pod-deny-host-alias/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package pod_deny_host_alias
 

--- a/examples/pod-deny-host-ipc/src_test.rego
+++ b/examples/pod-deny-host-ipc/src_test.rego
@@ -1,21 +1,17 @@
 package pod_deny_host_ipc
 
 test_hostipc_false {
-	input := {
+	not pod_has_hostipc with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"hostIPC": false},
 	}
-
-	not pod_has_hostipc with input as input
 }
 
 test_hostipc_true {
-	input := {
+	pod_has_hostipc with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"hostIPC": true},
 	}
-
-	pod_has_hostipc with input as input
 }

--- a/examples/pod-deny-host-ipc/template.yaml
+++ b/examples/pod-deny-host-ipc/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package pod_deny_host_ipc
 

--- a/examples/pod-deny-host-network/src.rego
+++ b/examples/pod-deny-host-network/src.rego
@@ -26,7 +26,10 @@ policyID := "P1006"
 violation[msg] {
 	pod_has_hostnetwork
 
-	msg := core.format_with_id(sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]),
+		policyID,
+	)
 }
 
 pod_has_hostnetwork {

--- a/examples/pod-deny-host-network/src_test.rego
+++ b/examples/pod-deny-host-network/src_test.rego
@@ -1,21 +1,17 @@
 package pod_deny_host_network
 
 test_hostnetwork_false {
-	input := {
+	not pod_has_hostnetwork with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"hostNetwork": false},
 	}
-
-	not pod_has_hostnetwork with input as input
 }
 
 test_hostnetwork_true {
-	input := {
+	pod_has_hostnetwork with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"hostNetwork": true},
 	}
-
-	pod_has_hostnetwork with input as input
 }

--- a/examples/pod-deny-host-network/template.yaml
+++ b/examples/pod-deny-host-network/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package pod_deny_host_network
 
@@ -110,7 +106,10 @@ spec:
       violation[msg] {
         pod_has_hostnetwork
 
-        msg := core.format_with_id(sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]),
+          policyID,
+        )
       }
 
       pod_has_hostnetwork {

--- a/examples/pod-deny-host-pid/src.rego
+++ b/examples/pod-deny-host-pid/src.rego
@@ -27,7 +27,10 @@ policyID := "P1007"
 violation[msg] {
 	pod_has_hostpid
 
-	msg := core.format_with_id(sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]),
+		policyID,
+	)
 }
 
 pod_has_hostpid {

--- a/examples/pod-deny-host-pid/src_test.rego
+++ b/examples/pod-deny-host-pid/src_test.rego
@@ -1,21 +1,17 @@
 package pod_deny_host_pid
 
 test_hostpid_false {
-	input := {
+	not pod_has_hostpid with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"hostPID": false},
 	}
-
-	not pod_has_hostpid with input as input
 }
 
 test_hostpid_true {
-	input := {
+	pod_has_hostpid with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"hostPID": true},
 	}
-
-	pod_has_hostpid with input as input
 }

--- a/examples/pod-deny-host-pid/template.yaml
+++ b/examples/pod-deny-host-pid/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package pod_deny_host_pid
 
@@ -110,7 +106,10 @@ spec:
       violation[msg] {
         pod_has_hostpid
 
-        msg := core.format_with_id(sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]),
+          policyID,
+        )
       }
 
       pod_has_hostpid {

--- a/examples/pod-deny-without-runasnonroot/src_test.rego
+++ b/examples/pod-deny-without-runasnonroot/src_test.rego
@@ -1,30 +1,24 @@
 package pod_deny_without_runasnonroot
 
 test_runasnonroot_true {
-	input := {
+	pod_runasnonroot with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"securityContext": {"runAsNonRoot": true}},
 	}
-
-	pod_runasnonroot with input as input
 }
 
 test_runasnonroot_null {
-	input := {
+	not pod_runasnonroot with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 	}
-
-	not pod_runasnonroot with input as input
 }
 
 test_runasnonroot_false {
-	input := {
+	not pod_runasnonroot with input as {
 		"kind": "Pod",
 		"metadata": {"name": "test-pod"},
 		"spec": {"securityContext": {"runAsNonRoot": false}},
 	}
-
-	not pod_runasnonroot with input as input
 }

--- a/examples/pod-deny-without-runasnonroot/template.yaml
+++ b/examples/pod-deny-without-runasnonroot/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -75,30 +73,28 @@ spec:
 
       import data.lib.core
 
-      default pod = false
+      default pod := false
 
-      pod = core.resource.spec.template {
+      pod := core.resource.spec.template {
         pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
         lower(core.kind) == pod_templates[_]
       }
 
-      pod = core.resource {
+      pod := core.resource {
         lower(core.kind) == "pod"
       }
 
-      pod = core.resource.spec.jobTemplate.spec.template {
+      pod := core.resource.spec.jobTemplate.spec.template {
         lower(core.kind) == "cronjob"
       }
 
       containers[container] {
-        keys = {"containers", "initContainers"}
-        all_containers = [c | keys[k]; c = pod.spec[k][_]]
-        container = all_containers[_]
+        keys := {"containers", "initContainers"}
+        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
+        container := all_containers[_]
       }
 
-      volumes[volume] {
-        volume = pod.spec.volumes[_]
-      }
+      volumes[pod.spec.volumes[_]]
     rego: |-
       package pod_deny_without_runasnonroot
 

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -58,7 +58,7 @@ violation[msg] {
   msg := core.format_with_id(sprintf("%s/%s: Missing required labels: %v", [core.kind, core.name, missing]), policyID)
 }
 
-missing_labels = missing {
+missing_labels := missing {
   provided := {label | core.labels[label]}
   required := {label | label := input.parameters.labels[_]}
   missing := required - provided
@@ -89,10 +89,14 @@ import data.lib.security
 policyID := "P1001"
 
 violation[msg] {
+  some container
   pods.containers[container]
   not container_dropped_all_capabilities(container)
 
-  msg := core.format_with_id(sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s/%s: Does not drop all capabilities", [core.kind, core.name, container.name]),
+    policyID,
+  )
 }
 
 container_dropped_all_capabilities(container) {
@@ -122,6 +126,7 @@ import data.lib.pods
 policyID := "P1002"
 
 violation[msg] {
+  some container
   pods.containers[container]
   container_allows_escalation(container)
 
@@ -165,10 +170,14 @@ import data.lib.security
 policyID := "P1003"
 
 violation[msg] {
+  some container
   pods.containers[container]
   container_is_privileged(container)
 
-  msg = core.format_with_id(sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s/%s: Containers must not run as privileged", [core.kind, core.name, container.name]),
+    policyID,
+  )
 }
 
 container_is_privileged(container) {
@@ -269,7 +278,10 @@ policyID := "P1006"
 violation[msg] {
   pod_has_hostnetwork
 
-  msg := core.format_with_id(sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s: Pod allows for accessing the host network", [core.kind, core.name]),
+    policyID,
+  )
 }
 
 pod_has_hostnetwork {
@@ -302,7 +314,10 @@ policyID := "P1007"
 violation[msg] {
   pod_has_hostpid
 
-  msg := core.format_with_id(sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s: Pod allows for accessing the host PID namespace", [core.kind, core.name]),
+    policyID,
+  )
 }
 
 pod_has_hostpid {
@@ -369,10 +384,14 @@ policyID := "P1009"
 violation[msg] {
   not psp_dropped_all_capabilities
 
-  msg := core.format_with_id(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]),
+    policyID,
+  )
 }
 
 psp_dropped_all_capabilities {
+  some psp
   psps.psps[psp]
   security.dropped_capability(psp, "all")
 }
@@ -400,6 +419,7 @@ import data.lib.psps
 policyID := "P1010"
 
 violation[msg] {
+  some psp
   psps.psps[psp]
   allows_escalation(psp)
 
@@ -471,7 +491,10 @@ policyID := "P1012"
 violation[msg] {
   psp_allows_hostipc
 
-  msg := core.format_with_id(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]),
+    policyID,
+  )
 }
 
 psp_allows_hostipc {
@@ -537,7 +560,10 @@ policyID := "P1014"
 violation[msg] {
   psp_allows_hostpid
 
-  msg = core.format_with_id(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]), policyID)
+  msg = core.format_with_id(
+    sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]),
+    policyID,
+  )
 }
 
 psp_allows_hostpid {
@@ -614,10 +640,14 @@ import data.lib.pods
 policyID := "P2001"
 
 violation[msg] {
+  some container
   pods.containers[container]
   has_latest_tag(container)
 
-  msg := core.format_with_id(sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s/%s: Images must not use the latest tag", [core.kind, core.name, container.name]),
+    policyID,
+  )
 }
 
 has_latest_tag(c) {
@@ -651,10 +681,14 @@ import data.lib.pods
 policyID := "P2002"
 
 violation[msg] {
+  some container
   pods.containers[container]
   not container_resources_provided(container)
 
-  msg := core.format_with_id(sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]),
+    policyID,
+  )
 }
 
 container_resources_provided(container) {
@@ -689,7 +723,10 @@ policyID := "P2005"
 violation[msg] {
   role_uses_privileged_psp
 
-  msg := core.format_with_id(sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]),
+    policyID,
+  )
 }
 
 role_uses_privileged_psp {
@@ -741,10 +778,14 @@ import data.lib.security
 policyID := "P2006"
 
 violation[msg] {
+  some container
   pods.containers[container]
   container_is_privileged(container)
 
-  msg = core.format_with_id(sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]), policyID)
+  msg = core.format_with_id(
+    sprintf("%s/%s/%s: Tenants' containers must not run as privileged", [core.kind, core.name, container.name]),
+    policyID,
+  )
 }
 
 container_is_privileged(container) {
@@ -773,16 +814,19 @@ the version for both of these resources must be `apps/v1`.
 ```rego
 package any_warn_deprecated_api_versions
 
-policyID := "P0001"
-
 import data.lib.core
+
+policyID := "P0001"
 
 warn[msg] {
   resources := ["DaemonSet", "Deployment"]
   core.apiVersion == "extensions/v1beta1"
   core.kind == resources[_]
 
-  msg := core.format_with_id(sprintf("API extensions/v1beta1 for %s has been deprecated, use apps/v1 instead.", [core.kind]), policyID)
+  msg := core.format_with_id(
+    sprintf("API extensions/v1beta1 for %s has been deprecated, use apps/v1 instead.", [core.kind]),
+    policyID,
+  )
 }
 ```
 
@@ -808,10 +852,14 @@ import data.lib.pods
 policyID := "P2003"
 
 warn[msg] {
+  some container
   pods.containers[container]
   no_read_only_filesystem(container)
 
-  msg := core.format_with_id(sprintf("%s/%s/%s: Is not using a read only root filesystem", [core.kind, core.name, container.name]), policyID)
+  msg := core.format_with_id(
+    sprintf("%s/%s/%s: Is not using a read only root filesystem", [core.kind, core.name, container.name]),
+    policyID,
+  )
 }
 
 no_read_only_filesystem(container) {
@@ -846,6 +894,7 @@ import data.lib.psps
 policyID := "P2004"
 
 warn[msg] {
+  some psp
   psps.psps[psp]
   no_read_only_filesystem(psp)
 

--- a/examples/psp-deny-added-caps/src.rego
+++ b/examples/psp-deny-added-caps/src.rego
@@ -22,10 +22,14 @@ policyID := "P1009"
 violation[msg] {
 	not psp_dropped_all_capabilities
 
-	msg := core.format_with_id(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]),
+		policyID,
+	)
 }
 
 psp_dropped_all_capabilities {
+	some psp
 	psps.psps[psp]
 	security.dropped_capability(psp, "all")
 }

--- a/examples/psp-deny-added-caps/src_test.rego
+++ b/examples/psp-deny-added-caps/src_test.rego
@@ -1,41 +1,33 @@
 package psp_deny_added_caps
 
 test_dropped_all {
-	input := {
+	psp_dropped_all_capabilities with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"requiredDropCapabilities": ["all"]},
 	}
-
-	psp_dropped_all_capabilities with input as input
 }
 
 test_case_insensitivty {
-	input := {
+	psp_dropped_all_capabilities with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"requiredDropCapabilities": ["aLl"]},
 	}
-
-	psp_dropped_all_capabilities with input as input
 }
 
 test_null {
-	input := {
+	not psp_dropped_all_capabilities with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"a": "b"},
 	}
-
-	not psp_dropped_all_capabilities with input as input
 }
 
 test_dropped_none {
-	input := {
+	not psp_dropped_all_capabilities with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"requiredDropCapabilities": ["none"]},
 	}
-
-	not psp_dropped_all_capabilities with input as input
 }

--- a/examples/psp-deny-added-caps/template.yaml
+++ b/examples/psp-deny-added-caps/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -128,10 +126,14 @@ spec:
       violation[msg] {
         not psp_dropped_all_capabilities
 
-        msg := core.format_with_id(sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s: Does not require droping all capabilities", [core.kind, core.name]),
+          policyID,
+        )
       }
 
       psp_dropped_all_capabilities {
+        some psp
         psps.psps[psp]
         security.dropped_capability(psp, "all")
       }

--- a/examples/psp-deny-escalation/src.rego
+++ b/examples/psp-deny-escalation/src.rego
@@ -18,6 +18,7 @@ import data.lib.psps
 policyID := "P1010"
 
 violation[msg] {
+	some psp
 	psps.psps[psp]
 	allows_escalation(psp)
 

--- a/examples/psp-deny-escalation/src_test.rego
+++ b/examples/psp-deny-escalation/src_test.rego
@@ -1,31 +1,25 @@
 package psp_deny_escalation
 
 test_allowescalation_false {
-	input := {
+	not allows_escalation({
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"allowPrivilegeEscalation": false},
-	}
-
-	not allows_escalation(input)
+	})
 }
 
 test_null {
-	input := {
+	allows_escalation({
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"a": "b"},
-	}
-
-	allows_escalation(input)
+	})
 }
 
 test_allowescalation_true {
-	input := {
+	allows_escalation({
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"allowPrivilegeEscalation": true},
-	}
-
-	allows_escalation(input)
+	})
 }

--- a/examples/psp-deny-escalation/template.yaml
+++ b/examples/psp-deny-escalation/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -103,6 +101,7 @@ spec:
       policyID := "P1010"
 
       violation[msg] {
+        some psp
         psps.psps[psp]
         allows_escalation(psp)
 

--- a/examples/psp-deny-host-alias/src_test.rego
+++ b/examples/psp-deny-host-alias/src_test.rego
@@ -1,21 +1,17 @@
 package psp_deny_host_alias
 
 test_hostaliases_false {
-	input := {
+	not psp_allows_hostaliases with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostAliases": false},
 	}
-
-	not psp_allows_hostaliases with input as input
 }
 
 test_hostaliases_true {
-	input := {
+	psp_allows_hostaliases with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostAliases": true},
 	}
-
-	psp_allows_hostaliases with input as input
 }

--- a/examples/psp-deny-host-alias/template.yaml
+++ b/examples/psp-deny-host-alias/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 

--- a/examples/psp-deny-host-ipc/src.rego
+++ b/examples/psp-deny-host-ipc/src.rego
@@ -20,7 +20,10 @@ policyID := "P1012"
 violation[msg] {
 	psp_allows_hostipc
 
-	msg := core.format_with_id(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]),
+		policyID,
+	)
 }
 
 psp_allows_hostipc {

--- a/examples/psp-deny-host-ipc/src_test.rego
+++ b/examples/psp-deny-host-ipc/src_test.rego
@@ -1,21 +1,17 @@
 package psp_deny_host_ipc
 
 test_hostipc_false {
-	input := {
+	not psp_allows_hostipc with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostIPC": false},
 	}
-
-	not psp_allows_hostipc with input as input
 }
 
 test_hostipc_true {
-	input := {
+	psp_allows_hostipc with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostIPC": true},
 	}
-
-	psp_allows_hostipc with input as input
 }

--- a/examples/psp-deny-host-ipc/template.yaml
+++ b/examples/psp-deny-host-ipc/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -105,7 +103,10 @@ spec:
       violation[msg] {
         psp_allows_hostipc
 
-        msg := core.format_with_id(sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s: Allows for sharing the host IPC namespace", [core.kind, core.name]),
+          policyID,
+        )
       }
 
       psp_allows_hostipc {

--- a/examples/psp-deny-host-network/src_test.rego
+++ b/examples/psp-deny-host-network/src_test.rego
@@ -1,21 +1,17 @@
 package psp_deny_host_network
 
 test_hostnetwork_false {
-	input := {
+	not psp_allows_hostnetwork with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostNetwork": false},
 	}
-
-	not psp_allows_hostnetwork with input as input
 }
 
 test_hostnetwork_true {
-	input := {
+	psp_allows_hostnetwork with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostNetwork": true},
 	}
-
-	psp_allows_hostnetwork with input as input
 }

--- a/examples/psp-deny-host-network/template.yaml
+++ b/examples/psp-deny-host-network/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 

--- a/examples/psp-deny-host-pid/src.rego
+++ b/examples/psp-deny-host-pid/src.rego
@@ -21,7 +21,10 @@ policyID := "P1014"
 violation[msg] {
 	psp_allows_hostpid
 
-	msg = core.format_with_id(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]), policyID)
+	msg = core.format_with_id(
+		sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]),
+		policyID,
+	)
 }
 
 psp_allows_hostpid {

--- a/examples/psp-deny-host-pid/src_test.rego
+++ b/examples/psp-deny-host-pid/src_test.rego
@@ -1,21 +1,17 @@
 package psp_deny_host_pid
 
 test_hostpid_false {
-	input := {
+	not psp_allows_hostpid with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostPID": false},
 	}
-
-	not psp_allows_hostpid with input as input
 }
 
 test_hostpid_true {
-	input := {
+	psp_allows_hostpid with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"hostPID": true},
 	}
-
-	psp_allows_hostpid with input as input
 }

--- a/examples/psp-deny-host-pid/template.yaml
+++ b/examples/psp-deny-host-pid/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -105,7 +103,10 @@ spec:
       violation[msg] {
         psp_allows_hostpid
 
-        msg = core.format_with_id(sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]), policyID)
+        msg = core.format_with_id(
+          sprintf("%s/%s: Allows for sharing the host PID namespace", [core.kind, core.name]),
+          policyID,
+        )
       }
 
       psp_allows_hostpid {

--- a/examples/psp-deny-privileged/src_test.rego
+++ b/examples/psp-deny-privileged/src_test.rego
@@ -1,21 +1,17 @@
 package psp_deny_privileged
 
 test_privileged_false {
-	input := {
+	not psp_allows_privileged with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"privileged": false},
 	}
-
-	not psp_allows_privileged with input as input
 }
 
 test_privileged_true {
-	input := {
+	psp_allows_privileged with input as {
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"privileged": true},
 	}
-
-	psp_allows_privileged with input as input
 }

--- a/examples/psp-deny-privileged/template.yaml
+++ b/examples/psp-deny-privileged/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 

--- a/examples/psp-warn-no-ro-fs/src.rego
+++ b/examples/psp-warn-no-ro-fs/src.rego
@@ -18,6 +18,7 @@ import data.lib.psps
 policyID := "P2004"
 
 warn[msg] {
+	some psp
 	psps.psps[psp]
 	no_read_only_filesystem(psp)
 

--- a/examples/psp-warn-no-ro-fs/src_test.rego
+++ b/examples/psp-warn-no-ro-fs/src_test.rego
@@ -1,31 +1,25 @@
 package psp_warn_no_ro_fs
 
 test_rofs_true {
-	input := {
+	not no_read_only_filesystem({
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"readOnlyRootFilesystem": true},
-	}
-
-	not no_read_only_filesystem(input)
+	})
 }
 
 test_null {
-	input := {
+	no_read_only_filesystem({
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"a": "b"},
-	}
-
-	no_read_only_filesystem(input)
+	})
 }
 
 test_rofs_false {
-	input := {
+	no_read_only_filesystem({
 		"kind": "PodSecurityPolicy",
 		"metadata": {"name": "test-psp"},
 		"spec": {"readOnlyRootFilesystem": false},
-	}
-
-	no_read_only_filesystem(input)
+	})
 }

--- a/examples/required-labels/src.rego
+++ b/examples/required-labels/src.rego
@@ -23,7 +23,7 @@ violation[msg] {
 	msg := core.format_with_id(sprintf("%s/%s: Missing required labels: %v", [core.kind, core.name, missing]), policyID)
 }
 
-missing_labels = missing {
+missing_labels := missing {
 	provided := {label | core.labels[label]}
 	required := {label | label := input.parameters.labels[_]}
 	missing := required - provided

--- a/examples/required-labels/template.yaml
+++ b/examples/required-labels/template.yaml
@@ -21,47 +21,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -92,7 +90,7 @@ spec:
         msg := core.format_with_id(sprintf("%s/%s: Missing required labels: %v", [core.kind, core.name, missing]), policyID)
       }
 
-      missing_labels = missing {
+      missing_labels := missing {
         provided := {label | core.labels[label]}
         required := {label | label := input.parameters.labels[_]}
         missing := required - provided

--- a/examples/role-deny-use-privileged-psp/src.rego
+++ b/examples/role-deny-use-privileged-psp/src.rego
@@ -20,7 +20,10 @@ policyID := "P2005"
 violation[msg] {
 	role_uses_privileged_psp
 
-	msg := core.format_with_id(sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]), policyID)
+	msg := core.format_with_id(
+		sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]),
+		policyID,
+	)
 }
 
 role_uses_privileged_psp {

--- a/examples/role-deny-use-privileged-psp/src_test.rego
+++ b/examples/role-deny-use-privileged-psp/src_test.rego
@@ -1,60 +1,48 @@
 package role_deny_use_privileged_psps
 
 test_role_uses_privileged_psp_match {
-	input := {"rules": [{
+	role_uses_privileged_psp with input as {"rules": [{
 		"resourceNames": ["test"],
 		"resources": ["podsecuritypolicies"],
 		"verbs": ["use"],
 	}]}
-
-	role_uses_privileged_psp with input as input
 }
 
 test_role_uses_privileged_psp_wildcard_verb {
-	input := {"rules": [{
+	role_uses_privileged_psp with input as {"rules": [{
 		"resourceNames": ["test"],
 		"resources": ["podsecuritypolicies"],
 		"verbs": ["*"],
 	}]}
-
-	role_uses_privileged_psp with input as input
 }
 
 test_role_uses_privileged_psp_no_resource_names {
-	input := {"rules": [{
+	role_uses_privileged_psp with input as {"rules": [{
 		"resources": ["podsecuritypolicies"],
 		"verbs": ["use"],
 	}]}
-
-	role_uses_privileged_psp with input as input
 }
 
 test_role_uses_privileged_psp_wrong_name {
-	input := {"rules": [{
+	not role_uses_privileged_psp with input as {"rules": [{
 		"resourceNames": ["wrong"],
 		"resources": ["podsecuritypolicies"],
 		"verbs": ["use"],
 	}]}
-
-	not role_uses_privileged_psp with input as input
 }
 
 test_role_uses_privileged_psp_wrong_resource_type {
-	input := {"rules": [{
+	not role_uses_privileged_psp with input as {"rules": [{
 		"resourceNames": ["test"],
 		"resources": ["wrong"],
 		"verbs": ["use"],
 	}]}
-
-	not role_uses_privileged_psp with input as input
 }
 
 test_role_uses_privileged_psp_wrong_verb {
-	input := {"rules": [{
+	not role_uses_privileged_psp with input as {"rules": [{
 		"resourceNames": ["test"],
 		"resources": ["podsecuritypolicies"],
 		"verbs": ["wrong"],
 	}]}
-
-	not role_uses_privileged_psp with input as input
 }

--- a/examples/role-deny-use-privileged-psp/template.yaml
+++ b/examples/role-deny-use-privileged-psp/template.yaml
@@ -13,47 +13,45 @@ spec:
     - |-
       package lib.core
 
-      default is_gatekeeper = false
+      default is_gatekeeper := false
 
       is_gatekeeper {
         has_field(input, "review")
         has_field(input.review, "object")
       }
 
-      resource = input.review.object {
+      resource := input.review.object {
         is_gatekeeper
       }
 
-      resource = input {
+      resource := input {
         not is_gatekeeper
       }
 
-      format(msg) = {"msg": msg}
+      format(msg) := {"msg": msg}
 
-      format_with_id(msg, id) = msg_fmt {
-        msg_fmt := {
-          "msg": sprintf("%s: %s", [id, msg]),
-          "details": {"policyID": id},
-        }
+      format_with_id(msg, id) := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id},
       }
 
-      apiVersion = resource.apiVersion
+      apiVersion := resource.apiVersion
 
-      name = resource.metadata.name
+      name := resource.metadata.name
 
-      kind = resource.kind
+      kind := resource.kind
 
-      labels = resource.metadata.labels
+      labels := resource.metadata.labels
 
-      annotations = resource.metadata.annotations
+      annotations := resource.metadata.annotations
 
       gv := split(apiVersion, "/")
 
-      group = gv[0] {
+      group := gv[0] {
         contains(apiVersion, "/")
       }
 
-      group = "core" {
+      group := "core" {
         not contains(apiVersion, "/")
       }
 
@@ -73,6 +71,8 @@ spec:
     - |-
       package lib.rbac
 
+      import future.keywords.in
+
       import data.lib.core
 
       rule_has_verb(rule, verb) {
@@ -86,10 +86,10 @@ spec:
       }
 
       rule_has_resource_name(rule, name) {
-        name == rule.resourceNames[_]
+        name in rule.resourceNames
       }
 
-      rule_has_resource_name(rule, name) {
+      rule_has_resource_name(rule, _) {
         core.missing_field(rule, "resourceNames")
       }
     - |-
@@ -126,7 +126,10 @@ spec:
       violation[msg] {
         role_uses_privileged_psp
 
-        msg := core.format_with_id(sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]), policyID)
+        msg := core.format_with_id(
+          sprintf("%s/%s: Allows using PodSecurityPolicies with privileged permissions", [core.kind, core.name]),
+          policyID,
+        )
       }
 
       role_uses_privileged_psp {


### PR DESCRIPTION
I think you're all familiar with [Regal](https://github.com/styrainc/regal) by now, so I'll skip the introduction :) This PR introduces the OPA community's favorite linter to the Konstraint project, and along with that a bunch of fixes as suggested by the linter.

Regal checks addressed:

* [import-after-rule](https://docs.styra.com/regal/rules/imports/import-after-rule)
* [line-length](https://docs.styra.com/regal/rules/style/line-length)
* [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)
* [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)
* [use-in-operator](https://docs.styra.com/regal/rules/idiomatic/use-in-operator)
* [use-some-for-output-vars](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars)

OPA strict mode compliance:

* Variables must not shadow `input`

Both have been added to the CI pipeline to ensure future compliance. Make sure to check in every once in a while, as new Regal releases are published quite frequently, and there's often some useful new rule included in each release.

Fixes #446