### PR TITLE
chore: multi arch builds

### DIFF
--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -41,5 +41,4 @@ jobs:
       run: >-
         docker buildx create --name builder &&
         docker buildx use --builder builder &&
-        make dockerx-build-push version=${TAG_NAME}
-
+        make dockerx-build version=${TAG_NAME}

--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -38,7 +38,8 @@ jobs:
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
     - name: docker build
-      run: make docker-build version=${TAG_NAME}
+      run: >-
+        docker buildx create --name builder &&
+        docker buildx use --builder builder &&
+        make dockerx-build-push version=${TAG_NAME}
 
-    - name: docker push
-      run: make docker-push version=${TAG_NAME}

--- a/Makefile
+++ b/Makefile
@@ -59,22 +59,6 @@ ifeq ($(version),)
 		.
 else
 	docker buildx build \
-		--platform "$(PLATFORMS)" \
-		-t konstraint:latest \
-		-t "konstraint:$(version)" \
-		--build-arg "KONSTRAINT_VER=$(version)" .
-endif
-
-.PHONY: dockerx-build-push
-dockerx-build-push: ## Builds and pushes the docker image. Can optionally pass in a version.
-ifeq ($(version),)
-	docker buildx build \
-		--push \
-		--platform "$(PLATFORMS)" \
-		-t konstraint:latest \
-		.
-else
-	docker buildx build \
 		--push \
 		--platform "$(PLATFORMS)" \
 		-t konstraint:latest \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 ## The repository where the container image will be pushed to.
 IMAGE := ghcr.io/plexsystems/konstraint
 
+PLATFORMS := linux/arm/v7,linux/arm64/v8,linux/amd64
+
 #
 ##@ Development
 #
@@ -46,6 +48,39 @@ ifeq ($(version),)
 	docker build -t konstraint:latest .
 else
 	docker build -t konstraint:latest -t konstraint:$(version) --build-arg KONSTRAINT_VER=$(version) .
+endif
+
+.PHONY: dockerx-build
+dockerx-build: ## Builds the docker image. Can optionally pass in a version.
+ifeq ($(version),)
+	docker buildx build \
+		--platform "$(PLATFORMS)" \
+		-t konstraint:latest \
+		.
+else
+	docker buildx build \
+		--platform "$(PLATFORMS)" \
+		-t konstraint:latest \
+		-t "konstraint:$(version)" \
+		--build-arg "KONSTRAINT_VER=$(version)" .
+endif
+
+.PHONY: dockerx-build-push
+dockerx-build-push: ## Builds and pushes the docker image. Can optionally pass in a version.
+ifeq ($(version),)
+	docker buildx build \
+		--push \
+		--platform "$(PLATFORMS)" \
+		-t konstraint:latest \
+		.
+else
+	docker buildx build \
+		--push \
+		--platform "$(PLATFORMS)" \
+		-t konstraint:latest \
+		-t "konstraint:$(version)" \
+		--build-arg "KONSTRAINT_VER=$(version)" \
+		.
 endif
 
 .PHONY: docker-push


### PR DESCRIPTION
Closes #489

`docker buildx` creates a little more modern docker images than `docker build` (read OCI) so a slight incompatibility may occur. `buiildx` is also a bit slow, in my test on github it took over 20 minuter. Perhaps it would be better to switch to ko as a build system?

But I haven't done that now.