### PR TITLE
ci: Include patch version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plexsystems/konstraint
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20220218180203-c2a0d8cdf85a


### PR DESCRIPTION
This is required for the toolchain line that Dependabot wants to add.