### PR TITLE
feat: update .Header.Resources to a string array

### DIFF
--- a/examples/policies-no-rego.md
+++ b/examples/policies-no-rego.md
@@ -33,7 +33,8 @@
 
 **Severity:** Violation
 
-**Resources:** Any Resource
+**Resources:**
+- Any Resource
 
 **Parameters:**
 
@@ -49,7 +50,11 @@ _source: [required-labels](required-labels)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -62,7 +67,11 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -74,7 +83,11 @@ _source: [container-deny-escalation](container-deny-escalation)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
@@ -87,7 +100,11 @@ _source: [container-deny-privileged](container-deny-privileged)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that can change aliases in the host's /etc/hosts file can redirect traffic to malicious servers.
 
@@ -98,7 +115,11 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -110,7 +131,11 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
@@ -122,7 +147,11 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that can access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -135,7 +164,11 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
@@ -147,7 +180,8 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -160,7 +194,8 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -172,7 +207,8 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
@@ -184,7 +220,8 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -196,7 +233,8 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -209,7 +247,8 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -222,7 +261,8 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -234,7 +274,11 @@ _source: [psp-deny-privileged](psp-deny-privileged)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Using the latest tag on images can cause unexpected problems in production. By specifying a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
@@ -261,7 +305,11 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Resource constraints on containers ensure that a given workload does not take up more resources than it requires
 and potentially starve other applications that need to run.
@@ -273,7 +321,8 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 
 **Severity:** Violation
 
-**Resources:** rbac.authorization.k8s.io/Role
+**Resources:**
+- rbac.authorization.k8s.io/Role
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
 
@@ -284,7 +333,11 @@ _source: [role-deny-use-privileged-psp](role-deny-use-privileged-psp)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 **MatchLabels:** is-tenant=true
 
@@ -301,7 +354,9 @@ _source: [container-deny-privileged-if-tenant](container-deny-privileged-if-tena
 
 **Severity:** Warning
 
-**Resources:** apps/DaemonSet apps/Deployment
+**Resources:**
+- apps/DaemonSet
+- apps/Deployment
 
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
@@ -314,7 +369,11 @@ _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 
 **Severity:** Warning
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
@@ -326,7 +385,8 @@ _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 
 **Severity:** Warning
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.

--- a/examples/policies-no-rego.md
+++ b/examples/policies-no-rego.md
@@ -34,6 +34,7 @@
 **Severity:** Violation
 
 **Resources:**
+
 - Any Resource
 
 **Parameters:**
@@ -51,6 +52,7 @@ _source: [required-labels](required-labels)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -68,6 +70,7 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -84,6 +87,7 @@ _source: [container-deny-escalation](container-deny-escalation)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -101,6 +105,7 @@ _source: [container-deny-privileged](container-deny-privileged)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -116,6 +121,7 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -132,6 +138,7 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -148,6 +155,7 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -165,6 +173,7 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -181,6 +190,7 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing containers privileged capabilities on the node makes it easier
@@ -195,6 +205,7 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
@@ -208,6 +219,7 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
@@ -221,6 +233,7 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host IPC can read memory of
@@ -234,6 +247,7 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
@@ -248,6 +262,7 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
@@ -262,6 +277,7 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
@@ -275,6 +291,7 @@ _source: [psp-deny-privileged](psp-deny-privileged)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -306,6 +323,7 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -322,6 +340,7 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 **Severity:** Violation
 
 **Resources:**
+
 - rbac.authorization.k8s.io/Role
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
@@ -334,6 +353,7 @@ _source: [role-deny-use-privileged-psp](role-deny-use-privileged-psp)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -355,6 +375,7 @@ _source: [container-deny-privileged-if-tenant](container-deny-privileged-if-tena
 **Severity:** Warning
 
 **Resources:**
+
 - apps/DaemonSet
 - apps/Deployment
 
@@ -370,6 +391,7 @@ _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 **Severity:** Warning
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -386,6 +408,7 @@ _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 **Severity:** Warning
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host's network interfaces can potentially

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -33,7 +33,8 @@
 
 **Severity:** Violation
 
-**Resources:** Any Resource
+**Resources:**
+- Any Resource
 
 **Parameters:**
 
@@ -71,7 +72,11 @@ _source: [required-labels](required-labels)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -110,7 +115,11 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -152,7 +161,11 @@ _source: [container-deny-escalation](container-deny-escalation)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
@@ -195,7 +208,11 @@ _source: [container-deny-privileged](container-deny-privileged)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that can change aliases in the host's /etc/hosts file can redirect traffic to malicious servers.
 
@@ -228,7 +245,11 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -260,7 +281,11 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
@@ -295,7 +320,11 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods that can access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -331,7 +360,11 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
@@ -364,7 +397,8 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -403,7 +437,8 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -441,7 +476,8 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
@@ -473,7 +509,8 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -508,7 +545,8 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -541,7 +579,8 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -577,7 +616,8 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 
 **Severity:** Violation
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -609,7 +649,11 @@ _source: [psp-deny-privileged](psp-deny-privileged)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Using the latest tag on images can cause unexpected problems in production. By specifying a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
@@ -665,7 +709,11 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 Resource constraints on containers ensure that a given workload does not take up more resources than it requires
 and potentially starve other applications that need to run.
@@ -705,7 +753,8 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 
 **Severity:** Violation
 
-**Resources:** rbac.authorization.k8s.io/Role
+**Resources:**
+- rbac.authorization.k8s.io/Role
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
 
@@ -756,7 +805,11 @@ _source: [role-deny-use-privileged-psp](role-deny-use-privileged-psp)_
 
 **Severity:** Violation
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 **MatchLabels:** is-tenant=true
 
@@ -803,7 +856,9 @@ _source: [container-deny-privileged-if-tenant](container-deny-privileged-if-tena
 
 **Severity:** Warning
 
-**Resources:** apps/DaemonSet apps/Deployment
+**Resources:**
+- apps/DaemonSet
+- apps/Deployment
 
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
@@ -836,7 +891,11 @@ _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 
 **Severity:** Warning
 
-**Resources:** core/Pod apps/DaemonSet apps/Deployment apps/StatefulSet
+**Resources:**
+- core/Pod
+- apps/DaemonSet
+- apps/Deployment
+- apps/StatefulSet
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
@@ -878,7 +937,8 @@ _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 
 **Severity:** Warning
 
-**Resources:** policy/PodSecurityPolicy
+**Resources:**
+- policy/PodSecurityPolicy
 
 Allowing pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -34,6 +34,7 @@
 **Severity:** Violation
 
 **Resources:**
+
 - Any Resource
 
 **Parameters:**
@@ -73,6 +74,7 @@ _source: [required-labels](required-labels)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -116,6 +118,7 @@ _source: [container-deny-added-caps](container-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -162,6 +165,7 @@ _source: [container-deny-escalation](container-deny-escalation)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -209,6 +213,7 @@ _source: [container-deny-privileged](container-deny-privileged)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -246,6 +251,7 @@ _source: [pod-deny-host-alias](pod-deny-host-alias)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -282,6 +288,7 @@ _source: [pod-deny-host-ipc](pod-deny-host-ipc)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -321,6 +328,7 @@ _source: [pod-deny-host-network](pod-deny-host-network)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -361,6 +369,7 @@ _source: [pod-deny-host-pid](pod-deny-host-pid)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -398,6 +407,7 @@ _source: [pod-deny-without-runasnonroot](pod-deny-without-runasnonroot)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing containers privileged capabilities on the node makes it easier
@@ -438,6 +448,7 @@ _source: [psp-deny-added-caps](psp-deny-added-caps)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
@@ -477,6 +488,7 @@ _source: [psp-deny-escalation](psp-deny-escalation)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
@@ -510,6 +522,7 @@ _source: [psp-deny-host-alias](psp-deny-host-alias)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host IPC can read memory of
@@ -546,6 +559,7 @@ _source: [psp-deny-host-ipc](psp-deny-host-ipc)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
@@ -580,6 +594,7 @@ _source: [psp-deny-host-network](psp-deny-host-network)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
@@ -617,6 +632,7 @@ _source: [psp-deny-host-pid](psp-deny-host-pid)_
 **Severity:** Violation
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
@@ -650,6 +666,7 @@ _source: [psp-deny-privileged](psp-deny-privileged)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -710,6 +727,7 @@ _source: [container-deny-latest-tag](container-deny-latest-tag)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -754,6 +772,7 @@ _source: [container-deny-without-resource-constraints](container-deny-without-re
 **Severity:** Violation
 
 **Resources:**
+
 - rbac.authorization.k8s.io/Role
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
@@ -806,6 +825,7 @@ _source: [role-deny-use-privileged-psp](role-deny-use-privileged-psp)_
 **Severity:** Violation
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -857,6 +877,7 @@ _source: [container-deny-privileged-if-tenant](container-deny-privileged-if-tena
 **Severity:** Warning
 
 **Resources:**
+
 - apps/DaemonSet
 - apps/Deployment
 
@@ -892,6 +913,7 @@ _source: [any-warn-deprecated-api-versions](any-warn-deprecated-api-versions)_
 **Severity:** Warning
 
 **Resources:**
+
 - core/Pod
 - apps/DaemonSet
 - apps/Deployment
@@ -938,6 +960,7 @@ _source: [container-warn-no-ro-fs](container-warn-no-ro-fs)_
 **Severity:** Warning
 
 **Resources:**
+
 - policy/PodSecurityPolicy
 
 Allowing pods to access the host's network interfaces can potentially

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -22,7 +22,7 @@ import (
 type Header struct {
 	Title       string
 	Description string
-	Resources   string
+	Resources   []string
 	MatchLabels string
 	Anchor      string
 	Parameters  []rego.Parameter
@@ -193,18 +193,18 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 			return nil, fmt.Errorf("parse matchers from legacy annotations: %w", err)
 		}
 
-		var matchResources string
+		var matchResources []string
 		if len(policy.AnnotationKindMatchers()) > 0 {
 			for _, akm := range policy.AnnotationKindMatchers() {
-				matchResources += akm.String() + " "
+				s := strings.Split(akm.String(), " ")
+				matchResources = append(matchResources, s...)
 			}
-			matchResources = strings.TrimSpace(matchResources)
 		} else {
-			matchResources = legacyMatchers.KindMatchers.String()
+			matchResources = strings.Split(legacyMatchers.KindMatchers.String(), " ")
 		}
-		if matchResources == "" {
+		if len(matchResources) == 0 {
 			logger.Warn("No kind matchers set, this can lead to poor policy performance.")
-			matchResources = "Any Resource"
+			matchResources = append(matchResources, "Any Resource")
 		}
 
 		var matchLabels string

--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -200,7 +200,9 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 				matchResources = append(matchResources, s...)
 			}
 		} else {
-			matchResources = strings.Split(legacyMatchers.KindMatchers.String(), " ")
+			if len(legacyMatchers.KindMatchers) > 0 {
+				matchResources = strings.Split(legacyMatchers.KindMatchers.String(), " ")
+			}
 		}
 		if len(matchResources) == 0 {
 			logger.Warn("No kind matchers set, this can lead to poor policy performance.")

--- a/internal/commands/document_template.tpl
+++ b/internal/commands/document_template.tpl
@@ -13,7 +13,10 @@
 
 **Severity:** {{ $severity }}
 
-**Resources:** {{ .Header.Resources }}
+**Resources:**
+{{ range .Header.Resources }}
+- {{ . }}
+{{- end }}
 
 {{- if .Header.MatchLabels }}
 


### PR DESCRIPTION
[`**Resources:** {{ .Header.Resources }}`](https://github.com/plexsystems/konstraint/blob/c4e8d7653f437b266bbba7aceae34bdd82a6acad/internal/commands/document_template.tpl#L16C1-L16C39) is hard to read when many resources are specified because they are space separated.

This PR proposes replacing `.Header.Resources` with a string array.