### PR TITLE
added _ as a replacement for kind name

### DIFF
--- a/internal/rego/rego.go
+++ b/internal/rego/rego.go
@@ -382,6 +382,7 @@ func (r Rego) Severity() Severity {
 func (r Rego) Kind() string {
 	kind := filepath.Base(filepath.Dir(r.Path()))
 	kind = strings.ReplaceAll(kind, "-", " ")
+	kind = strings.ReplaceAll(kind, "_", " ")
 	kind = cases.Title(language.AmericanEnglish).String(kind)
 	kind = strings.ReplaceAll(kind, " ", "")
 


### PR DESCRIPTION
with the latest release of regal, it adds a check for to make sure the package names matches the path.
- https://docs.styra.com/regal/rules/idiomatic/directory-package-mismatch

My paths have traditionally included a `-` and the package (which doesn't allow `-`) uses `_`. with this new check, I've made the paths match the packages but that then means the generated `name` for templates is invalid.

this PR adds `_` to the replacement list for names