### PR TITLE
chore: Bump Go to 1.23

### DIFF
--- a/.github/workflows/cron_e2e.yaml
+++ b/.github/workflows/cron_e2e.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: checkout
         uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
       - name: lint go
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.61
           args: --timeout=5m --color=always --max-same-issues=0 --max-issues-per-linter=0
 
   acceptance:
@@ -31,7 +31,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
 
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/update_cli_docs.yaml
+++ b/.github/workflows/update_cli_docs.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: checkout source
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plexsystems/konstraint
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20220218180203-c2a0d8cdf85a


### PR DESCRIPTION
This mirrors the Dockerfile change in https://github.com/plexsystems/konstraint/pull/536