### PR TITLE
fix: Sort parameters in docs

### DIFF
--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -220,6 +220,9 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 		if len(policy.AnnotationParameters()) > 0 {
 			parameters = annoParamsToLegacyFormat(policy.AnnotationParameters())
 		}
+		sort.Slice(parameters, func(i, j int) bool {
+			return parameters[i].Name < parameters[j].Name
+		})
 
 		header := Header{
 			Title:       documentTitle,


### PR DESCRIPTION
This fixes https://github.com/plexsystems/konstraint/issues/550 (parameters are sometimes randomly reordered in the policies.md file).