### PR TITLE
ci: Add --v0-compatible flag to "opa check"

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -102,7 +102,7 @@ jobs:
           version: latest
 
       - name: opa check strict
-        run: opa check --strict --ignore "*.yaml" examples
+        run: opa check --v0-compatible --strict --ignore "*.yaml" examples
 
       - name: setup regal
         uses: styrainc/setup-regal@v1.0.0


### PR DESCRIPTION
Konstraint is currently still supporting Rego V0 syntax.