### PR TITLE
Lint/improve YAML in policies docs

### DIFF
--- a/examples/container_deny_latest_tag/src.rego
+++ b/examples/container_deny_latest_tag/src.rego
@@ -6,17 +6,17 @@
 #
 #   The following snippet is an example of how to satisfy this requirement:
 #
-#    ```
-#    apiVersion: apps/v1
-#    kind: Deployment
-#    metadata:
-#      name: redis
-#    spec:
-#      template:
-#        spec:
-#          containers:
-#            - name: redis
-#              image: redis:6.2
+#   ```yaml
+#   apiVersion: apps/v1
+#   kind: Deployment
+#   metadata:
+#     name: redis
+#   spec:
+#     template:
+#       spec:
+#         containers:
+#           - name: redis
+#             image: redis:6.2
 #   ```
 # custom:
 #   matchers:

--- a/examples/policies-no-rego.md
+++ b/examples/policies-no-rego.md
@@ -36,15 +36,14 @@
 
 **Resources:**
 
-- Any Resource
+* Any Resource
 
 **Parameters:**
 
 * labels: array of string
   Array of required label keys.
 
-This policy allows you to require certain labels are set on a resource. Adapted from https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml
-
+This policy allows you to require certain labels are set on a resource. Adapted from <https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml>
 
 _source: [required_labels](required_labels)_
 
@@ -54,15 +53,14 @@ _source: [required_labels](required_labels)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
-
 
 _source: [container_deny_added_caps](container_deny_added_caps)_
 
@@ -72,14 +70,13 @@ _source: [container_deny_added_caps](container_deny_added_caps)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 
 _source: [container_deny_escalation](container_deny_escalation)_
 
@@ -89,15 +86,14 @@ _source: [container_deny_escalation](container_deny_escalation)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
 to obtain the same effect are not allowed.
-
 
 _source: [container_deny_privileged](container_deny_privileged)_
 
@@ -107,13 +103,12 @@ _source: [container_deny_privileged](container_deny_privileged)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that can change aliases in the host's /etc/hosts file can redirect traffic to malicious servers.
-
 
 _source: [pod_deny_host_alias](pod_deny_host_alias)_
 
@@ -123,14 +118,13 @@ _source: [pod_deny_host_alias](pod_deny_host_alias)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
-
 
 _source: [pod_deny_host_ipc](pod_deny_host_ipc)_
 
@@ -140,14 +134,13 @@ _source: [pod_deny_host_ipc](pod_deny_host_ipc)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
-
 
 _source: [pod_deny_host_network](pod_deny_host_network)_
 
@@ -157,15 +150,14 @@ _source: [pod_deny_host_network](pod_deny_host_network)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that can access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 
 _source: [pod_deny_host_pid](pod_deny_host_pid)_
 
@@ -175,14 +167,13 @@ _source: [pod_deny_host_pid](pod_deny_host_pid)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
-
 
 _source: [pod_deny_without_runasnonroot](pod_deny_without_runasnonroot)_
 
@@ -192,12 +183,11 @@ _source: [pod_deny_without_runasnonroot](pod_deny_without_runasnonroot)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
 outside of Kubernetes controller namespaces.
-
 
 _source: [psp_deny_added_caps](psp_deny_added_caps)_
 
@@ -207,11 +197,10 @@ _source: [psp_deny_added_caps](psp_deny_added_caps)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 
 _source: [psp_deny_escalation](psp_deny_escalation)_
 
@@ -221,11 +210,10 @@ _source: [psp_deny_escalation](psp_deny_escalation)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
-
 
 _source: [psp_deny_host_alias](psp_deny_host_alias)_
 
@@ -235,11 +223,10 @@ _source: [psp_deny_host_alias](psp_deny_host_alias)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host IPC can read memory of
 the other containers, breaking that security boundary.
-
 
 _source: [psp_deny_host_ipc](psp_deny_host_ipc)_
 
@@ -249,12 +236,11 @@ _source: [psp_deny_host_ipc](psp_deny_host_ipc)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 
 _source: [psp_deny_host_network](psp_deny_host_network)_
 
@@ -264,12 +250,11 @@ _source: [psp_deny_host_network](psp_deny_host_network)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
 boundary.
-
 
 _source: [psp_deny_host_pid](psp_deny_host_pid)_
 
@@ -279,11 +264,10 @@ _source: [psp_deny_host_pid](psp_deny_host_pid)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
-
 
 _source: [psp_deny_privileged](psp_deny_privileged)_
 
@@ -293,29 +277,28 @@ _source: [psp_deny_privileged](psp_deny_privileged)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Using the latest tag on images can cause unexpected problems in production. By specifying a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
 
 The following snippet is an example of how to satisfy this requirement:
 
- ```
- apiVersion: apps/v1
- kind: Deployment
- metadata:
-   name: redis
- spec:
-   template:
-     spec:
-       containers:
-         - name: redis
-           image: redis:6.2
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  template:
+    spec:
+      containers:
+        - name: redis
+          image: redis:6.2
 ```
-
 
 _source: [container_deny_latest_tag](container_deny_latest_tag)_
 
@@ -325,14 +308,13 @@ _source: [container_deny_latest_tag](container_deny_latest_tag)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Resource constraints on containers ensure that a given workload does not take up more resources than it requires
 and potentially starve other applications that need to run.
-
 
 _source: [container_deny_without_resource_constraints](container_deny_without_resource_constraints)_
 
@@ -342,10 +324,9 @@ _source: [container_deny_without_resource_constraints](container_deny_without_re
 
 **Resources:**
 
-- rbac\.authorization\.k8s\.io/Role
+* rbac\.authorization\.k8s\.io/Role
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
-
 
 _source: [role_deny_use_privileged_psps](role_deny_use_privileged_psps)_
 
@@ -355,10 +336,10 @@ _source: [role_deny_use_privileged_psps](role_deny_use_privileged_psps)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 **MatchLabels:** is\-tenant=true
 
@@ -368,7 +349,6 @@ to obtain the same effect are not allowed if they are labeled as tenant.
 To take advantage of this policy, it must be combined with another policy
 that enforces the 'is-tenant' label.
 
-
 _source: [container_deny_privileged_if_tenant](container_deny_privileged_if_tenant)_
 
 ## P0001: Deprecated Deployment and DaemonSet API
@@ -377,13 +357,12 @@ _source: [container_deny_privileged_if_tenant](container_deny_privileged_if_tena
 
 **Resources:**
 
-- apps/DaemonSet
-- apps/Deployment
+* apps/DaemonSet
+* apps/Deployment
 
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
 the version for both of these resources must be `apps/v1`.
-
 
 _source: [any_warn_deprecated_api_versions](any_warn_deprecated_api_versions)_
 
@@ -393,7 +372,7 @@ _source: [any_warn_deprecated_api_versions](any_warn_deprecated_api_versions)_
 
 **Resources:**
 
-- \*/Pod
+* \*/Pod
 
 **MatchLabels:** \_test\_=true
 
@@ -403,7 +382,6 @@ _source: [any_warn_deprecated_api_versions](any_warn_deprecated_api_versions)_
 
 This is only here to test and illustrate _punctuation_ / Markdown handling
 
-
 _source: [policy_markdown_punctuation](policy_markdown_punctuation)_
 
 ## P2003: Containers should not have a writable root filesystem
@@ -412,14 +390,13 @@ _source: [policy_markdown_punctuation](policy_markdown_punctuation)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
-
 
 _source: [container_warn_no_ro_fs](container_warn_no_ro_fs)_
 
@@ -429,11 +406,9 @@ _source: [container_warn_no_ro_fs](container_warn_no_ro_fs)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
 
-
 _source: [psp_warn_no_ro_fs](psp_warn_no_ro_fs)_
-

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -36,14 +36,14 @@
 
 **Resources:**
 
-- Any Resource
+* Any Resource
 
 **Parameters:**
 
 * labels: array of string
   Array of required label keys.
 
-This policy allows you to require certain labels are set on a resource. Adapted from https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml
+This policy allows you to require certain labels are set on a resource. Adapted from <https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml>
 
 ### Rego
 
@@ -80,10 +80,10 @@ _source: [required_labels](required_labels)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Granting containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -126,10 +126,10 @@ _source: [container_deny_added_caps](container_deny_added_caps)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -175,10 +175,10 @@ _source: [container_deny_escalation](container_deny_escalation)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Privileged containers can easily escalate to root privileges on the node. As
 such containers running as privileged or with sufficient capabilities granted
@@ -225,10 +225,10 @@ _source: [container_deny_privileged](container_deny_privileged)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that can change aliases in the host's /etc/hosts file can redirect traffic to malicious servers.
 
@@ -266,10 +266,10 @@ _source: [pod_deny_host_alias](pod_deny_host_alias)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that are allowed to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -305,10 +305,10 @@ _source: [pod_deny_host_ipc](pod_deny_host_ipc)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that can access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
@@ -347,10 +347,10 @@ _source: [pod_deny_host_network](pod_deny_host_network)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods that can access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -390,10 +390,10 @@ _source: [pod_deny_host_pid](pod_deny_host_pid)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Pods running as root (uid of 0) can much more easily escalate privileges
 to root on the node. As such, they are not allowed.
@@ -430,7 +430,7 @@ _source: [pod_deny_without_runasnonroot](pod_deny_without_runasnonroot)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing containers privileged capabilities on the node makes it easier
 for containers to escalate their privileges. As such, this is not allowed
@@ -473,7 +473,7 @@ _source: [psp_deny_added_caps](psp_deny_added_caps)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -515,7 +515,7 @@ _source: [psp_deny_escalation](psp_deny_escalation)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to can change aliases in the host's /etc/hosts file can
 redirect traffic to malicious servers.
@@ -551,7 +551,7 @@ _source: [psp_deny_host_alias](psp_deny_host_alias)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host IPC can read memory of
 the other containers, breaking that security boundary.
@@ -590,7 +590,7 @@ _source: [psp_deny_host_ipc](psp_deny_host_ipc)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -627,7 +627,7 @@ _source: [psp_deny_host_network](psp_deny_host_network)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host's process tree can view and attempt to
 modify processes outside of their namespace, breaking that security
@@ -667,7 +667,7 @@ _source: [psp_deny_host_pid](psp_deny_host_pid)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing privileged containers can much more easily obtain root on the node.
 As such, they are not allowed.
@@ -703,27 +703,27 @@ _source: [psp_deny_privileged](psp_deny_privileged)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Using the latest tag on images can cause unexpected problems in production. By specifying a pinned version
 we can have higher confidence that our applications are immutable and do not change unexpectedly.
 
 The following snippet is an example of how to satisfy this requirement:
 
- ```
- apiVersion: apps/v1
- kind: Deployment
- metadata:
-   name: redis
- spec:
-   template:
-     spec:
-       containers:
-         - name: redis
-           image: redis:6.2
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  template:
+    spec:
+      containers:
+        - name: redis
+          image: redis:6.2
 ```
 
 ### Rego
@@ -766,10 +766,10 @@ _source: [container_deny_latest_tag](container_deny_latest_tag)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 Resource constraints on containers ensure that a given workload does not take up more resources than it requires
 and potentially starve other applications that need to run.
@@ -813,7 +813,7 @@ _source: [container_deny_without_resource_constraints](container_deny_without_re
 
 **Resources:**
 
-- rbac\.authorization\.k8s\.io/Role
+* rbac\.authorization\.k8s\.io/Role
 
 Workloads not running in the exempted namespaces must not use PodSecurityPolicies with privileged permissions.
 
@@ -868,10 +868,10 @@ _source: [role_deny_use_privileged_psps](role_deny_use_privileged_psps)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 **MatchLabels:** is\-tenant=true
 
@@ -922,8 +922,8 @@ _source: [container_deny_privileged_if_tenant](container_deny_privileged_if_tena
 
 **Resources:**
 
-- apps/DaemonSet
-- apps/Deployment
+* apps/DaemonSet
+* apps/Deployment
 
 The `extensions/v1beta1 API` has been deprecated in favor of `apps/v1`. Later versions of Kubernetes
 remove this API so to ensure that the Deployment or DaemonSet can be successfully deployed to the cluster,
@@ -961,7 +961,7 @@ _source: [any_warn_deprecated_api_versions](any_warn_deprecated_api_versions)_
 
 **Resources:**
 
-- \*/Pod
+* \*/Pod
 
 **MatchLabels:** \_test\_=true
 
@@ -996,10 +996,10 @@ _source: [policy_markdown_punctuation](policy_markdown_punctuation)_
 
 **Resources:**
 
-- core/Pod
-- apps/DaemonSet
-- apps/Deployment
-- apps/StatefulSet
+* core/Pod
+* apps/DaemonSet
+* apps/Deployment
+* apps/StatefulSet
 
 In order to prevent persistence in the case of a compromise, it is
 important to make the root filesystem read-only.
@@ -1045,7 +1045,7 @@ _source: [container_warn_no_ro_fs](container_warn_no_ro_fs)_
 
 **Resources:**
 
-- policy/PodSecurityPolicy
+* policy/PodSecurityPolicy
 
 Allowing pods to access the host's network interfaces can potentially
 access and tamper with traffic the pod should not have access to.
@@ -1080,4 +1080,3 @@ no_read_only_filesystem(psp) if {
 ```
 
 _source: [psp_warn_no_ro_fs](psp_warn_no_ro_fs)_
-

--- a/examples/required_labels/src.rego
+++ b/examples/required_labels/src.rego
@@ -2,7 +2,7 @@
 # title: Required Labels
 # description: >-
 #  This policy allows you to require certain labels are set on a resource.
-#  Adapted from https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml
+#  Adapted from <https://github.com/open-policy-agent/gatekeeper/blob/master/example/templates/k8srequiredlabels_template.yaml>
 # custom:
 #   parameters:
 #     labels:

--- a/internal/commands/document_template.tpl
+++ b/internal/commands/document_template.tpl
@@ -15,7 +15,7 @@
 
 **Resources:**
 {{ range .Header.Resources }}
-- {{ . }}
+* {{ . }}
 {{- end }}
 
 {{- if .Header.MatchLabels }}
@@ -34,14 +34,15 @@
 {{- end }}
 
 {{ .Header.Description }}
-{{ if ne .Rego "" }}
+
+{{ if ne .Rego "" -}}
 ### Rego
 {{ $codeblock := "```" }}
 {{ $codeblock }}rego
 {{ .Rego }}
-{{ $codeblock }}{{- end }}
+{{ $codeblock }}
 
+{{ end -}}
 _source: [{{ .URL }}]({{ .URL }})_
-{{ end }}
-
-{{- end }}
+{{end -}}
+{{end -}}


### PR DESCRIPTION
All of the unordered lists should use asterisks for consistency.  It's also harder to confuse them with YAML arrays.  There are also two cases in which YAML embedded in a src.rego file causes lint warnings in the output.  The rest of the template changes fix various cases in which there are two consecutive blank lines.