### PR TITLE
Generate v1 constrainttemplates by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ acceptance: build ## Runs the acceptance tests.
 
 .PHONY: policy
 policy: ## Runs the policy tests.
-	conftest verify -p examples
+	conftest verify -p examples -d examples/test-data
 
 .PHONY: update-static
 update-static: build ## Updates the static assets in the repository.

--- a/docs/cli/konstraint_create.md
+++ b/docs/cli/konstraint_create.md
@@ -24,7 +24,7 @@ Create constraints with the Gatekeeper enforcement action set to dryrun
 ```
       --constraint-custom-template-file string            Path to a custom template file to generate constraints
       --constraint-template-custom-template-file string   Path to a custom template file to generate constraint templates
-      --constraint-template-version string                Set the version of ConstraintTemplates (default "v1beta1")
+      --constraint-template-version string                Set the version of ConstraintTemplates (default "v1")
   -d, --dryrun                                            Set the enforcement action of the constraints to dryrun, overriding the @enforcement tag
   -h, --help                                              help for create
       --log-level string                                  Set a log level. Options: error, info, debug, trace (default "info")

--- a/examples/container_deny_added_caps/template.yaml
+++ b/examples/container_deny_added_caps/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/container_deny_escalation/template.yaml
+++ b/examples/container_deny_escalation/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/container_deny_latest_tag/template.yaml
+++ b/examples/container_deny_latest_tag/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/container_deny_privileged/template.yaml
+++ b/examples/container_deny_privileged/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/container_deny_privileged_if_tenant/template.yaml
+++ b/examples/container_deny_privileged_if_tenant/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/container_deny_without_resource_constraints/template.yaml
+++ b/examples/container_deny_without_resource_constraints/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/pod_deny_host_alias/template.yaml
+++ b/examples/pod_deny_host_alias/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/pod_deny_host_ipc/template.yaml
+++ b/examples/pod_deny_host_ipc/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/pod_deny_host_network/template.yaml
+++ b/examples/pod_deny_host_network/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/pod_deny_host_pid/template.yaml
+++ b/examples/pod_deny_host_pid/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/pod_deny_without_runasnonroot/template.yaml
+++ b/examples/pod_deny_without_runasnonroot/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/psp_deny_added_caps/template.yaml
+++ b/examples/psp_deny_added_caps/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/psp_deny_escalation/template.yaml
+++ b/examples/psp_deny_escalation/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/psp_deny_host_alias/template.yaml
+++ b/examples/psp_deny_host_alias/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/psp_deny_host_ipc/template.yaml
+++ b/examples/psp_deny_host_ipc/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/psp_deny_host_network/template.yaml
+++ b/examples/psp_deny_host_network/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/psp_deny_host_pid/template.yaml
+++ b/examples/psp_deny_host_pid/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/psp_deny_privileged/template.yaml
+++ b/examples/psp_deny_privileged/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/examples/required_labels/template.yaml
+++ b/examples/required_labels/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null
@@ -16,6 +16,7 @@ spec:
               items:
                 type: string
               type: array
+          type: object
   targets:
   - libs:
     - |-

--- a/examples/role_deny_use_privileged_psps/template.yaml
+++ b/examples/role_deny_use_privileged_psps/template.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -90,7 +90,7 @@ Create constraints with the Gatekeeper enforcement action set to dryrun
 	cmd.PersistentFlags().StringP("output", "o", "", "Specify an output directory for the Gatekeeper resources")
 	cmd.PersistentFlags().BoolP("dryrun", "d", false, "Set the enforcement action of the constraints to dryrun, overriding the @enforcement tag")
 	cmd.PersistentFlags().Bool("skip-constraints", false, "Skip generation of constraints")
-	cmd.PersistentFlags().String("constraint-template-version", "v1beta1", "Set the version of ConstraintTemplates")
+	cmd.PersistentFlags().String("constraint-template-version", "v1", "Set the version of ConstraintTemplates")
 	cmd.PersistentFlags().Bool("partial-constraints", false, "Generate partial Constraints for policies with parameters")
 	cmd.PersistentFlags().String("constraint-template-custom-template-file", "", "Path to a custom template file to generate constraint templates")
 	cmd.PersistentFlags().String("constraint-custom-template-file", "", "Path to a custom template file to generate constraints")

--- a/internal/commands/create_test.go
+++ b/internal/commands/create_test.go
@@ -85,7 +85,7 @@ func TestRenderConstraintTemplate(t *testing.T) {
 	// Need to remove carriage return for testing on windows
 	expected = bytes.Replace(expected, []byte("\r"), []byte(""), -1)
 
-	actual, err := renderConstraintTemplate(violations[0], "v1beta1", "", entry.LastEntry())
+	actual, err := renderConstraintTemplate(violations[0], "v1", "", entry.LastEntry())
 	if err != nil {
 		t.Errorf("Error rendering constrainttemplate: %v", err)
 	}

--- a/test/template_Test.yaml
+++ b/test/template_Test.yaml
@@ -1,4 +1,4 @@
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null
@@ -16,6 +16,7 @@ spec:
                 super duper cool parameter with a description
                 on two lines.
               type: string
+          type: object
   targets:
   - libs:
     - |-


### PR DESCRIPTION
v1 constrainttemplate CRDs in gatekeeper should be around long enough, so it should be safe to switch it over to this version. 