### PR TITLE
Add log-level support

### DIFF
--- a/docs/cli/konstraint_create.md
+++ b/docs/cli/konstraint_create.md
@@ -25,8 +25,9 @@ Create constraints with the Gatekeeper enforcement action set to dryrun
       --constraint-custom-template-file string            Path to a custom template file to generate constraints
       --constraint-template-custom-template-file string   Path to a custom template file to generate constraint templates
       --constraint-template-version string                Set the version of ConstraintTemplates (default "v1beta1")
-  -d, --dryrun                                            Sets the enforcement action of the constraints to dryrun, overriding the @enforcement tag
+  -d, --dryrun                                            Set the enforcement action of the constraints to dryrun, overriding the @enforcement tag
   -h, --help                                              help for create
+      --log-level string                                  Set a log level. Options: error, info, debug, trace (default "info")
   -o, --output string                                     Specify an output directory for the Gatekeeper resources
       --partial-constraints                               Generate partial Constraints for policies with parameters
       --skip-constraints                                  Skip generation of constraints


### PR DESCRIPTION
Add minimal support for log-levels this helps to find the failing policy if you run through multiple of them. (as konstraint only takes a folder as input)