### PR TITLE
feat: Make policy available in doc command

### DIFF
--- a/internal/commands/document.go
+++ b/internal/commands/document.go
@@ -36,6 +36,7 @@ type Document struct {
 	Header Header
 	URL    string
 	Rego   string
+	Policy rego.Rego
 }
 
 //go:embed document_template.tpl
@@ -308,6 +309,7 @@ func getDocumentation(path string, outputDirectory string) (map[rego.Severity][]
 			Header: header,
 			URL:    url,
 			Rego:   rego,
+			Policy: policy,
 		}
 
 		if policy.Severity() == "" {

--- a/internal/commands/document_policy_csv.tpl
+++ b/internal/commands/document_policy_csv.tpl
@@ -1,0 +1,6 @@
+{{/* This is an example how to create a CSV file that includes the policy ID and the policy name */}}
+{{- range $severity, $value := . }}
+{{- range . }}
+{{ .Policy.PolicyID | default "-" }},{{ .Policy.Name }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This gives more flexibility when using `konstraint doc`, we use it to generate a CSV file that looks like this:

```
P0002,requiredlabels
P1001,containerdenyaddedcaps
P1002,containerdenyescalation
P1003,containerdenyprivileged
P1004,poddenyhostalias
P1005,poddenyhostipc
P1006,poddenyhostnetwork
P1007,poddenyhostpid
P1008,poddenywithoutrunasnonroot
P1009,pspdenyaddedcaps
P1010,pspdenyescalation
P1011,pspdenyhostalias
P1012,pspdenyhostipc
P1013,pspdenyhostnetwork
P1014,pspdenyhostpid
P1015,pspdenyprivileged
P123456,test
P2001,containerdenylatesttag
P2002,containerdenywithoutresourceconstraints
P2005,roledenyuseprivilegedpsps
P2006,containerdenyprivilegediftenant
P0001,anywarndeprecatedapiversions
P0003,policymarkdownpunctuation
P2003,containerwarnnorofs
P2004,pspwarnnorofs
```