### PR TITLE
ci: Remove E2E prep dependency on acceptance tests

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -159,9 +159,6 @@ jobs:
   e2e-prep:
     name: Prep for End-to-end Tests
     runs-on: ubuntu-latest
-    needs:
-      - lint
-      - acceptance
 
     steps:
       - name: checkout source
@@ -179,6 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - e2e-prep
+      - acceptance
     strategy:
       matrix:
         gk-version: ${{ fromJson(needs.e2e-prep.outputs.gk-versions) }}


### PR DESCRIPTION
This lets the PR workflow complete a little faster.