### PR TITLE
Add support for DELETE operations

### DIFF
--- a/examples/container_deny_added_caps/template.yaml
+++ b/examples/container_deny_added_caps/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/container_deny_escalation/template.yaml
+++ b/examples/container_deny_escalation/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/container_deny_latest_tag/template.yaml
+++ b/examples/container_deny_latest_tag/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/container_deny_privileged/template.yaml
+++ b/examples/container_deny_privileged/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/container_deny_privileged_if_tenant/template.yaml
+++ b/examples/container_deny_privileged_if_tenant/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/lib/core.rego
+++ b/examples/lib/core.rego
@@ -9,11 +9,22 @@ is_gatekeeper if {
 	has_field(input.review, "object")
 }
 
-resource := input.review.object if {
-	is_gatekeeper
+is_gatekeeper if {
+	has_field(input, "review")
+	has_field(input.review, "oldObject")
 }
 
-resource := input if {
+resource := input.review.object if {
+	is_gatekeeper
+	has_field(input.review, "object")
+}
+
+else := input.review.oldObject if {
+	is_gatekeeper
+	has_field(input.review, "oldObject")
+}
+
+else := input if {
 	not is_gatekeeper
 }
 
@@ -33,6 +44,12 @@ kind := resource.kind
 labels := resource.metadata.labels
 
 annotations := resource.metadata.annotations
+
+operation := input.review.operation if {
+	is_gatekeeper
+} else := input.operation if {
+	not is_gatekeeper
+}
 
 gv := split(apiVersion, "/")
 

--- a/examples/lib/core_test.rego
+++ b/examples/lib/core_test.rego
@@ -10,6 +10,10 @@ test_is_gk if {
 	is_gatekeeper with input as {"review": {"object": {"kind": "test"}}}
 }
 
+test_is_gk_oldobject if {
+	is_gatekeeper with input as {"review": {"oldObject": {"kind": "test"}}}
+}
+
 test_has_field_pos if {
 	has_field({"kind": "test"}, "kind")
 }

--- a/examples/namespace_deny_deletion/constraint.yaml
+++ b/examples/namespace_deny_deletion/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: NamespaceDenyDeletion
+metadata:
+  name: namespacedenydeletion
+spec:
+  match:
+    kinds:
+    - apiGroups:
+      - ""
+      kinds:
+      - Namespace

--- a/examples/namespace_deny_deletion/src.rego
+++ b/examples/namespace_deny_deletion/src.rego
@@ -1,0 +1,31 @@
+# METADATA
+# title: Namespace deletion must be denied unless explicitly allowed
+# description: >-
+#   Prevent deletion of Kubernetes namespaces to avoid accidental or unauthorized removal of critical workloads.
+# custom:
+#   matchers:
+#     kinds:
+#     - apiGroups:
+#       - ""
+#       kinds:
+#       - Namespace
+package namespace_deny_delete
+
+import data.lib.core
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.if
+
+policyID := "P2007"
+
+violation contains msg if {
+	core.kind == "Namespace"
+	core.operation == "DELETE"
+	not allow_namespace_deletion
+
+	msg := core.format_with_id(sprintf("%s/%s: Deletion of Namespace is not allowed", [core.kind, core.name]), policyID)
+}
+
+allow_namespace_deletion if {
+	core.annotations["allow-deletion"] == "true"
+}

--- a/examples/namespace_deny_deletion/src_test.rego
+++ b/examples/namespace_deny_deletion/src_test.rego
@@ -1,0 +1,25 @@
+package namespace_deny_delete
+
+import future.keywords.if
+
+test_deny_namespace_delete_without_annotation if {
+	not allow_namespace_deletion with input as {
+		"kind": "Namespace",
+		"metadata": {
+			"name": "my-ns",
+			"annotations": {},
+		},
+		"operation": "DELETE",
+	}
+}
+
+test_allow_namespace_delete_with_annotation if {
+	allow_namespace_deletion with input as {
+		"kind": "Namespace",
+		"metadata": {
+			"name": "safe-ns",
+			"annotations": {"allow-deletion": "true"},
+		},
+		"operation": "DELETE",
+	}
+}

--- a/examples/namespace_deny_deletion/template.yaml
+++ b/examples/namespace_deny_deletion/template.yaml
@@ -2,12 +2,12 @@ apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null
-  name: containerdenywithoutresourceconstraints
+  name: namespacedenydeletion
 spec:
   crd:
     spec:
       names:
-        kind: ContainerDenyWithoutResourceConstraints
+        kind: NamespaceDenyDeletion
   targets:
   - libs:
     - |-
@@ -87,62 +87,26 @@ spec:
       missing_field(obj, field) if {
         not has_field(obj, field)
       }
-    - |-
-      package lib.pods
-
-      import future.keywords.contains
-      import future.keywords.if
-
-      import data.lib.core
-
-      default pod := false
-
-      pod := core.resource.spec.template if {
-        pod_templates := ["daemonset", "deployment", "job", "replicaset", "replicationcontroller", "statefulset"]
-        lower(core.kind) == pod_templates[_]
-      }
-
-      pod := core.resource if {
-        lower(core.kind) == "pod"
-      }
-
-      pod := core.resource.spec.jobTemplate.spec.template if {
-        lower(core.kind) == "cronjob"
-      }
-
-      containers contains container if {
-        keys := {"containers", "initContainers"}
-        all_containers := [c | some k; keys[k]; c = pod.spec[k][_]]
-        container := all_containers[_]
-      }
-
-      volumes contains pod.spec.volumes[_]
     rego: |-
-      package container_deny_without_resource_constraints
+      package namespace_deny_delete
 
       import data.lib.core
-      import data.lib.pods
       import future.keywords.contains
       import future.keywords.if
+      import future.keywords.if
 
-      policyID := "P2002"
+      policyID := "P2007"
 
       violation contains msg if {
-        some container
-        pods.containers[container]
-        not container_resources_provided(container)
+        core.kind == "Namespace"
+        core.operation == "DELETE"
+        not allow_namespace_deletion
 
-        msg := core.format_with_id(
-          sprintf("%s/%s/%s: Container resource constraints must be specified", [core.kind, core.name, container.name]),
-          policyID,
-        )
+        msg := core.format_with_id(sprintf("%s/%s: Deletion of Namespace is not allowed", [core.kind, core.name]), policyID)
       }
 
-      container_resources_provided(container) if {
-        container.resources.requests.cpu
-        container.resources.requests.memory
-        container.resources.limits.cpu
-        container.resources.limits.memory
+      allow_namespace_deletion if {
+        core.annotations["allow-deletion"] == "true"
       }
     target: admission.k8s.gatekeeper.sh
 status: {}

--- a/examples/pod_deny_host_alias/template.yaml
+++ b/examples/pod_deny_host_alias/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/pod_deny_host_ipc/template.yaml
+++ b/examples/pod_deny_host_ipc/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/pod_deny_host_network/template.yaml
+++ b/examples/pod_deny_host_network/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/pod_deny_host_pid/template.yaml
+++ b/examples/pod_deny_host_pid/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/pod_deny_without_runasnonroot/template.yaml
+++ b/examples/pod_deny_without_runasnonroot/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/policies-no-rego.md
+++ b/examples/policies-no-rego.md
@@ -22,6 +22,7 @@
 * [P2002: Containers must define resource constraints](#p2002-containers-must-define-resource-constraints)
 * [P2005: Roles must not allow use of privileged PodSecurityPolicies](#p2005-roles-must-not-allow-use-of-privileged-podsecuritypolicies)
 * [P2006: Tenants' containers must not run as privileged](#p2006-tenants-containers-must-not-run-as-privileged)
+* [P2007: Namespace deletion must be denied unless explicitly allowed](#p2007-namespace-deletion-must-be-denied-unless-explicitly-allowed)
 
 ## Warnings
 
@@ -350,6 +351,18 @@ To take advantage of this policy, it must be combined with another policy
 that enforces the 'is-tenant' label.
 
 _source: [container_deny_privileged_if_tenant](container_deny_privileged_if_tenant)_
+
+## P2007: Namespace deletion must be denied unless explicitly allowed
+
+**Severity:** Violation
+
+**Resources:**
+
+* core/Namespace
+
+Prevent deletion of Kubernetes namespaces to avoid accidental or unauthorized removal of critical workloads.
+
+_source: [namespace_deny_deletion](namespace_deny_deletion)_
 
 ## P0001: Deprecated Deployment and DaemonSet API
 

--- a/examples/policies.md
+++ b/examples/policies.md
@@ -22,6 +22,7 @@
 * [P2002: Containers must define resource constraints](#p2002-containers-must-define-resource-constraints)
 * [P2005: Roles must not allow use of privileged PodSecurityPolicies](#p2005-roles-must-not-allow-use-of-privileged-podsecuritypolicies)
 * [P2006: Tenants' containers must not run as privileged](#p2006-tenants-containers-must-not-run-as-privileged)
+* [P2007: Namespace deletion must be denied unless explicitly allowed](#p2007-namespace-deletion-must-be-denied-unless-explicitly-allowed)
 
 ## Warnings
 
@@ -915,6 +916,43 @@ container_is_privileged(container) if {
 ```
 
 _source: [container_deny_privileged_if_tenant](container_deny_privileged_if_tenant)_
+
+## P2007: Namespace deletion must be denied unless explicitly allowed
+
+**Severity:** Violation
+
+**Resources:**
+
+* core/Namespace
+
+Prevent deletion of Kubernetes namespaces to avoid accidental or unauthorized removal of critical workloads.
+
+### Rego
+
+```rego
+package namespace_deny_delete
+
+import data.lib.core
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.if
+
+policyID := "P2007"
+
+violation contains msg if {
+  core.kind == "Namespace"
+  core.operation == "DELETE"
+  not allow_namespace_deletion
+
+  msg := core.format_with_id(sprintf("%s/%s: Deletion of Namespace is not allowed", [core.kind, core.name]), policyID)
+}
+
+allow_namespace_deletion if {
+  core.annotations["allow-deletion"] == "true"
+}
+```
+
+_source: [namespace_deny_deletion](namespace_deny_deletion)_
 
 ## P0001: Deprecated Deployment and DaemonSet API
 

--- a/examples/psp_deny_added_caps/template.yaml
+++ b/examples/psp_deny_added_caps/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/psp_deny_escalation/template.yaml
+++ b/examples/psp_deny_escalation/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/psp_deny_host_alias/template.yaml
+++ b/examples/psp_deny_host_alias/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/psp_deny_host_ipc/template.yaml
+++ b/examples/psp_deny_host_ipc/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/psp_deny_host_network/template.yaml
+++ b/examples/psp_deny_host_network/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/psp_deny_host_pid/template.yaml
+++ b/examples/psp_deny_host_pid/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/psp_deny_privileged/template.yaml
+++ b/examples/psp_deny_privileged/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/required_labels/template.yaml
+++ b/examples/required_labels/template.yaml
@@ -31,11 +31,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -55,6 +66,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 

--- a/examples/role_deny_use_privileged_psps/template.yaml
+++ b/examples/role_deny_use_privileged_psps/template.yaml
@@ -22,11 +22,22 @@ spec:
         has_field(input.review, "object")
       }
 
-      resource := input.review.object if {
-        is_gatekeeper
+      is_gatekeeper if {
+        has_field(input, "review")
+        has_field(input.review, "oldObject")
       }
 
-      resource := input if {
+      resource := input.review.object if {
+        is_gatekeeper
+        has_field(input.review, "object")
+      }
+
+      else := input.review.oldObject if {
+        is_gatekeeper
+        has_field(input.review, "oldObject")
+      }
+
+      else := input if {
         not is_gatekeeper
       }
 
@@ -46,6 +57,12 @@ spec:
       labels := resource.metadata.labels
 
       annotations := resource.metadata.annotations
+
+      operation := input.review.operation if {
+        is_gatekeeper
+      } else := input.operation if {
+        not is_gatekeeper
+      }
 
       gv := split(apiVersion, "/")
 


### PR DESCRIPTION
## Summary

This change extends the core Rego library to support safely handling `input.review.oldObject`, and `input.review.operation`.

## Details

- Updates `resource` to use:
  - `input.review.object` if present
  - fallback to `input.review.oldObject` in case of DELETE operations.

- Adds logic to expose `core.operation` using:
  - `input.review.operation` for Gatekeeper

## Why

Gatekeeper policies for `DELETE` operations often need access to:
- The previous state (`review.oldObject`)
- The operation type (`review.operation`)


## Example Use Case

A policy can now safely evaluate:

```rego
core.kind == "Namespace"
core.operation == "DELETE"
```

